### PR TITLE
[feat] 버튼 컴포넌트 구현

### DIFF
--- a/src/components/common/button/Button.tsx
+++ b/src/components/common/button/Button.tsx
@@ -15,7 +15,7 @@ interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
 
 const SIZE_STYLES: Record<ButtonSize, string> = {
   lg: 'h-12 px-6 text-caption1',
-  md: 'h-10 px-5 text-caption5',
+  md: 'h-10.5 px-5 text-caption5',
   sm: 'h-8 px-3 text-body1',
 };
 

--- a/src/components/common/button/Button.tsx
+++ b/src/components/common/button/Button.tsx
@@ -15,8 +15,8 @@ interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
 
 const SIZE_STYLES: Record<ButtonSize, string> = {
   lg: 'h-12 px-6 text-caption1',
-  md: 'h-10.5 px-5 text-caption5',
-  sm: 'h-8 px-3 text-body1',
+  md: 'h-9.5 px-5.5 text-caption5',
+  sm: 'h-8 px-5 text-body1',
 };
 
 const BASE_STYLE =

--- a/src/components/common/button/Button.tsx
+++ b/src/components/common/button/Button.tsx
@@ -1,0 +1,86 @@
+import React from 'react';
+import { cn } from '@/utils/cn';
+
+type ButtonVariant = 'solid' | 'outline' | 'tag';
+type ButtonColor = 'green' | 'yellow' | 'gray';
+type ButtonSize = 'lg' | 'md' | 'sm';
+
+interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: ButtonVariant;
+  color?: ButtonColor;
+  size?: ButtonSize;
+  fullWidth?: boolean;
+  selected?: boolean;
+}
+
+const SIZE_STYLES: Record<ButtonSize, string> = {
+  lg: 'h-12 px-6 text-caption1',
+  md: 'h-10 px-5 text-caption5',
+  sm: 'h-8 px-3 text-body1',
+};
+
+const BASE_STYLE =
+  'inline-flex items-center justify-center rounded-m transition-colors duration-150 active:scale-95 disabled:cursor-not-allowed';
+
+const Button: React.FC<ButtonProps> = ({
+  variant = 'solid',
+  color = 'green',
+  size = 'md',
+  fullWidth,
+  selected,
+  disabled,
+  className,
+  children,
+  ...props
+}) => {
+  let style = '';
+
+  // ==== SOLID 버튼 ====
+  if (variant === 'solid') {
+    if (disabled) {
+      style = 'bg-gray1 btn-text-gray3';
+    } else {
+      style = cn(
+        color === 'green' && 'bg-green1 btn-text-white hover:bg-green2',
+        color === 'yellow' && 'bg-yellow btn-text-black hover:brightness-95',
+        color === 'gray' && 'bg-gray2 btn-text-white hover:bg-gray3'
+      );
+    }
+  }
+
+  // ==== OUTLINE 버튼 ====
+  if (variant === 'outline') {
+    style = cn(
+      'bg-transparent',
+      color === 'green' &&
+        'btn-text-green1 border border-green1 hover:bg-beige2',
+      color === 'gray' &&
+        'btn-text-gray3 border border-gray3 hover:bg-gray1'
+    );
+  }
+
+  // ==== TAG 버튼 ====
+  if (variant === 'tag') {
+    style = cn(
+      selected ? 'bg-yellow btn-text-black' : 'bg-green1 btn-text-white'
+    );
+  }
+
+  return (
+    <button
+      {...props}
+      disabled={disabled}
+      className={cn(
+        BASE_STYLE,
+        SIZE_STYLES[size],
+        fullWidth && 'w-full',
+        style,
+        className
+      )}
+    >
+      {children}
+    </button>
+  );
+};
+
+export default Button;

--- a/src/components/common/button/Button.tsx
+++ b/src/components/common/button/Button.tsx
@@ -20,7 +20,7 @@ const SIZE_STYLES: Record<ButtonSize, string> = {
 };
 
 const BASE_STYLE =
-  'inline-flex items-center justify-center rounded-m transition-colors duration-150 active:scale-95 disabled:cursor-not-allowed';
+  'cursor-pointer inline-flex items-center justify-center rounded-m transition-colors duration-150 active:scale-95 disabled:cursor-not-allowed';
 
 const Button: React.FC<ButtonProps> = ({
   variant = 'solid',

--- a/src/components/index.tsx
+++ b/src/components/index.tsx
@@ -1,0 +1,3 @@
+import Button from "@/components/common/button/Button";
+
+export {Button};

--- a/src/components/test/ButtonTest.tsx
+++ b/src/components/test/ButtonTest.tsx
@@ -1,0 +1,100 @@
+import Button from '@/components/common/button/Button';
+import { useState } from 'react';
+
+const genres = ['판타지', '로맨스', '자연 과학', 'SF', '어쩌고 저쩌고', '이런거'];
+
+const ButtonTest = () => {
+  const [selectedGenres, setSelectedGenres] = useState<string[]>([]);
+
+  const toggleGenre = (genre: string) => {
+    setSelectedGenres((prev) =>
+      prev.includes(genre)
+        ? prev.filter((g) => g !== genre)
+        : [...prev, genre]
+    );
+  };
+
+  return (
+    <div className="space-y-10 bg-beige1 p-4">
+      {/* 1. 로그인 / 회원가입 */}
+      <section>
+        <h1 className="mb-4 text-title3">1. 로그인 / 회원가입 버튼</h1>
+
+        <div className="space-y-3">
+          <Button variant="solid" color="green" size="lg" fullWidth>
+            로그인
+          </Button>
+
+          <Button variant="solid" color="yellow" size="lg" fullWidth>
+            회원 가입
+          </Button>
+        </div>
+      </section>
+
+      {/* 2. 토론 타입 */}
+      <section>
+        <h1 className="mb-4 text-title3">2. 토론 타입 버튼</h1>
+
+        <div className="flex gap-3">
+          <Button variant="solid" color="green" size="md">
+            자유토론
+          </Button>
+          <Button variant="outline" color="green" size="md">
+            VS 토론
+          </Button>
+        </div>
+      </section>
+
+      {/* 3. 다음 버튼 */}
+      <section>
+        <h1 className="mb-4 text-title3">3. 다음 버튼</h1>
+
+        <div className="space-y-3">
+          <Button variant="solid" color="yellow" size="lg" fullWidth>
+            다음
+          </Button>
+
+          <Button
+            variant="solid"
+            color="gray"
+            size="lg"
+            fullWidth
+            disabled
+          >
+            다음
+          </Button>
+        </div>
+      </section>
+
+      {/* 4. 태그 다중 선택 */}
+      <section>
+        <h1 className="mb-4 text-title3">4. 장르 태그 (다중 선택)</h1>
+
+        <div className="flex flex-wrap gap-2">
+          {genres.map((g) => (
+            <Button
+              key={g}
+              variant="tag"
+              size="sm"
+              selected={selectedGenres.includes(g)}
+              onClick={() => toggleGenre(g)}
+            >
+              {g}
+            </Button>
+          ))}
+        </div>
+
+        <p className="mt-3 text-body4 text-gray3">
+          선택된 장르:{' '}
+          <span className="text-body3 text-green1">
+            {selectedGenres.length > 0
+              ? selectedGenres.join(', ')
+              : '없음'}
+          </span>
+        </p>
+      </section>
+    </div>
+  );
+};
+
+export default ButtonTest;

--- a/src/index.css
+++ b/src/index.css
@@ -1,4 +1,4 @@
-@import '..\public\fonts\fonts.css';
+@import '../public/fonts/fonts.css';
 @import 'tailwindcss';
 
 /*필요에 따라 추가해서 쓰시면 됩니다!*/

--- a/src/index.css
+++ b/src/index.css
@@ -1,4 +1,4 @@
-@import '../public/fonts/fonts.css';
+@import '..\public\fonts\fonts.css';
 @import 'tailwindcss';
 
 /*필요에 따라 추가해서 쓰시면 됩니다!*/
@@ -63,7 +63,7 @@
   html,
   body {
     @apply mx-auto h-screen max-w-[430px];
-    font-family: var(--font-suit);
+    font-family: var(--font-default);
     background-color: var(--color-beige1);
     color: var(--color-black);
     scrollbar-gutter: stable;
@@ -207,6 +207,24 @@
     background-color: var(--color-yellow);
   }
 
+  /*버튼 텍스트 색상*/
+  .btn-text-white{
+    color: var(--color-white);
+  }
+
+  .btn-text-black{
+    color: var(--color-black);
+  }
+
+  .btn-text-green1{
+    color: var(--color-green1);
+  }
+
+  .btn-text-gray3{
+    color: var(--color-gray3);
+  }
+
+
   /*텍스트 색상*/
   .text-gray1 {
     color: var(--color-gray1);
@@ -234,6 +252,10 @@
 
   .text-green2 {
     color: var(--color-green2);
+  }
+
+  .text-white{
+    color: var(--color-white);
   }
 
   /*border*/

--- a/src/routes/route.tsx
+++ b/src/routes/route.tsx
@@ -1,6 +1,7 @@
 import { createBrowserRouter } from 'react-router-dom';
 import TextTest from '@/components/test/textTest';
 import HomePage from '@/pages/main/Homepage';
+import ButtonTest from '@/components/test/ButtonTest';
 
 export const router = createBrowserRouter([
   {
@@ -10,5 +11,9 @@ export const router = createBrowserRouter([
   {
     path:'/test-text',
     element: <TextTest/>
+  },
+  {
+    path: '/test-button',
+    element: <ButtonTest/>
   }
 ]);

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,8 @@
+/** @type {import('tailwindcss').Config} */
+export default {
+  content: ['./index.html', './src/**/*.{js,ts,jsx,tsx}'],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};


### PR DESCRIPTION
## 📝 작업 내용

- figma를 기반으로 재사용 가능한 공통 Button 컴포넌트를 추가하였습니다.
- 버튼 스타일 (variant, color, size 등)을 props로 제어할 수 있도록 구현하였습니다. 사용하실 때 어려우시면 components/test/ButtonTest.tsx 파일에 예시 구현해두었으니 참고하시면 됩니다!
- 좋아요 버튼은 추후 뱃지 컴포넌트가 구현된 후에 거기에 맞추어 구현하겠습니다

## 📸 스크린샷 (선택)
https://github.com/user-attachments/assets/49a20baf-03ba-491b-a89e-cab37bc21a8a


## 📢 발생한 이슈

## ✨ 리뷰어에게
```
interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
  variant?: ButtonVariant;  // 기본값: 'solid'
  color?: ButtonColor;      // 기본값: 'green'
  size?: ButtonSize;        // 기본값: 'md'
  fullWidth?: boolean;      // true 시 width 100%
  selected?: boolean;       // tag 타입에서 선택 상태 표현
}
```

## 🔗 관련 이슈

- closed #9 