### PR TITLE
[Feat] 온보딩 페이지 1, 2 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "react-router-dom": "^7.9.6",
         "tailwind-merge": "^3.4.0",
         "vite-plugin-svgr": "^4.5.0",
-        "zustand": "^5.0.8"
+        "zustand": "^5.0.9"
       },
       "devDependencies": {
         "@eslint/js": "^9.39.1",
@@ -4849,9 +4849,9 @@
       }
     },
     "node_modules/zustand": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.8.tgz",
-      "integrity": "sha512-gyPKpIaxY9XcO2vSMrLbiER7QMAMGOQZVRdJ6Zi782jkbzZygq5GI9nG8g+sMgitRtndwaBSl7uiqC49o1SSiw==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.9.tgz",
+      "integrity": "sha512-ALBtUj0AfjJt3uNRQoL1tL2tMvj6Gp/6e39dnfT6uzpelGru8v1tPOGBzayOWbPJvujM8JojDk3E1LxeFisBNg==",
       "license": "MIT",
       "engines": {
         "node": ">=12.20.0"

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "react-router-dom": "^7.9.6",
     "tailwind-merge": "^3.4.0",
     "vite-plugin-svgr": "^4.5.0",
-    "zustand": "^5.0.8"
+    "zustand": "^5.0.9"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.1",

--- a/src/components/common/badge/Badge.tsx
+++ b/src/components/common/badge/Badge.tsx
@@ -74,7 +74,7 @@ const Badge: React.FC<BadgeProps> = (props) => {
   const { visible = true, className } = props as CheckBadgeProps;
   if (!visible) return null;
 
-  return <CheckIcon className={cn("w-6 h-6", className)} />;
+  return <CheckIcon className={cn("w-9 h-9", className)} />;  //체크 뱃지 크기 수정
 };
 
 export default Badge;

--- a/src/pages/onboarding/OnboardingPage1.tsx
+++ b/src/pages/onboarding/OnboardingPage1.tsx
@@ -1,0 +1,77 @@
+import React from "react";
+import { useNavigate } from "react-router-dom";
+
+import {Header, Button, Input} from '@/components'; 
+
+import { useOnboardingStore } from "@/store/useOnboardingStore";
+
+const OnboardingPage1: React.FC = () => {
+  const navigate = useNavigate();
+  const { nickname, setNickname } = useOnboardingStore();
+
+  const isFilled = nickname.trim().length > 0;
+
+  const handleNext = () => {
+    if (!isFilled) return;
+    navigate("/onboardingPage2");
+  };
+
+  return (
+    <div className="bg-beige1 h-screen w-full flex flex-col overflow-hidden items-center">
+      
+      {/* 1. 헤더 */}
+      <Header
+        variant="back"
+        onBackClick={() => navigate(-1)}
+        className="w-full flex-shrink-0"
+      />
+
+      {/* 2. 진행 바 */}
+      <div className="w-full h-[6px] bg-gray1 flex-shrink-0">
+        <div className="h-full bg-green1 w-1/4 transition-all duration-300" />
+      </div>
+
+      {/* 3. 메인 컨텐츠 영역 */}
+      <main className="flex-1 w-full max-w-[375px] mx-auto px-[18px] overflow-y-auto">
+        
+        {/* 타이틀 영역 */}
+        <section className="mt-5 mb-12">
+          <h1 className="text-title3 text-black whitespace-pre-line">
+            프로필을 만들어주세요
+          </h1>
+        </section>
+
+        {/* 닉네임 입력 영역 */}
+        <section className="flex flex-col gap-3">
+          <label className="text-caption2 text-black pl-[5px]">닉네임</label>
+          <Input
+            type="text"
+            fullWidth
+            value={nickname}
+            onChange={(e) => setNickname(e.target.value)}
+          />
+        </section>
+
+      </main>
+
+      {/* 4. 하단 버튼 영역 (고정) */}
+      <div className="w-full max-w-[363px] mx-auto px-[18px] pb-10 bg-beige1 flex-shrink-0 pt-4 relative">
+        
+        <Button
+          type="submit"
+          variant="solid"
+          color="yellow" 
+          size="lg"
+          fullWidth
+          disabled={!isFilled}
+          onClick={handleNext}
+        >
+          다음
+        </Button>
+      </div>
+
+    </div>
+  );
+};
+
+export default OnboardingPage1;

--- a/src/pages/onboarding/OnboardingPage2.tsx
+++ b/src/pages/onboarding/OnboardingPage2.tsx
@@ -72,12 +72,13 @@ const OnboardingPage2: React.FC = () => {
                 // store에 있는 함수 실행
                 onClick={() => toggleBookSelect(book.id)}
               >
-                <div className="w-full h-full rounded-m overflow-hidden relative">
+                <div className="w-full h-full overflow-hidden relative">
                   <div className="absolute inset-0 bg-gray2" /> 
                   <Image
                     src={book.imageUrl}
                     alt={book.title}
                     className="h-full w-full object-cover"
+                    rounded="rounded-none"
                   />
                   {isSelected && <div className="absolute inset-0 bg-green1/20" />}
                 </div>

--- a/src/pages/onboarding/OnboardingPage2.tsx
+++ b/src/pages/onboarding/OnboardingPage2.tsx
@@ -1,0 +1,119 @@
+import React from "react";
+import { useNavigate } from "react-router-dom";
+
+import {Header, Button, Image, Badge} from '@/components';
+
+import { useOnboardingStore } from "@/store/useOnboardingStore";
+
+// 타입 및 더미 데이터
+type Book = {
+  id: number;
+  title: string;
+  imageUrl: string;
+};
+
+const dummyBooks: Book[] = Array.from({ length: 100 }).map((_, idx) => ({
+  id: idx + 1,
+  title: `Book ${idx + 1}`,
+  imageUrl: `https://picsum.photos/seed/onboarding-${idx}/200/300`,
+}));
+
+const OnboardingPage2: React.FC = () => {
+  const navigate = useNavigate();
+
+  // useState 대신 store
+  // 이 데이터는 페이지를 떠나도 사라지지 않게 한다.
+  const { selectedBookIds, toggleBookSelect } = useOnboardingStore();
+
+  const hasSelection = selectedBookIds.length > 0;
+
+  const handleNext = () => {
+    if (!hasSelection) return;
+    console.log("선택된 책 ID들:", selectedBookIds);
+    navigate("/onboardingPage3");
+  };
+
+  return (
+    <div className="bg-beige1 h-screen w-full flex flex-col overflow-hidden items-center">
+      
+      {/* 1. 헤더 */}
+      <Header
+        variant="back"
+        onBackClick={() => navigate(-1)}
+        className="w-full flex-shrink-0"
+      />
+
+      {/* 2. 진행 바 */}
+      <div className="w-full h-[6px] bg-gray1 flex-shrink-0">
+        <div className="h-full bg-green1 w-1/2 transition-all duration-300" />
+      </div>
+
+      {/* 3. 스크롤 영역 */}
+      <main className="flex-1 w-full max-w-[375px] px-[18px] overflow-y-auto">
+        {/* 타이틀 */}
+        <section className="mt-5 mb-6">
+          <h1 className="text-title3 text-black whitespace-pre-line">
+            베스트 셀러 목록에서{"\n"}
+            좋아하는 책을 선택해보세요
+          </h1>
+          <p className="text-body1 text-green2 mt-3">
+            최대 5권까지 선택할 수 있어요!
+          </p>
+        </section>
+
+        <section className="grid grid-cols-3 gap-x-4 gap-y-6 pb-4">
+          {dummyBooks.map((book) => {
+            // store에서 가져온 selectedBookIds로 확인
+            const isSelected = selectedBookIds.includes(book.id);
+            return (
+              <div
+                key={book.id}
+                className="relative aspect-[2/3] w-full cursor-pointer"
+                // store에 있는 함수 실행
+                onClick={() => toggleBookSelect(book.id)}
+              >
+                <div className="w-full h-full rounded-m overflow-hidden relative">
+                  <div className="absolute inset-0 bg-gray2" /> 
+                  <Image
+                    src={book.imageUrl}
+                    alt={book.title}
+                    className="h-full w-full object-cover"
+                  />
+                  {isSelected && <div className="absolute inset-0 bg-green1/20" />}
+                </div>
+
+                <Badge
+                  variant="check"
+                  visible={isSelected}
+                  className="absolute top-0 right-0"
+                />
+              </div>
+            );
+          })}
+        </section>
+      </main>
+
+      {/* 4. 하단 버튼 영역 */}
+      <div className="w-full max-w-[363px] px-[18px] pb-10 bg-beige1 flex-shrink-0 pt-4 relative">
+        <div 
+            className="absolute left-0 right-0 bottom-full h-10 pointer-events-none"
+            style={{ background: "linear-gradient(to top, #F9F5E8, transparent)" }}
+        />
+
+        <Button
+          variant="solid"
+          color={hasSelection ? "yellow" : "gray"}
+          size="lg"
+          fullWidth
+          disabled={!hasSelection}
+          onClick={handleNext}
+        >
+          다음
+        </Button>
+      </div>
+
+    </div>
+  );
+};
+
+export default OnboardingPage2;

--- a/src/pages/onboarding/OnboardingPage2.tsx
+++ b/src/pages/onboarding/OnboardingPage2.tsx
@@ -85,7 +85,7 @@ const OnboardingPage2: React.FC = () => {
                 <Badge
                   variant="check"
                   visible={isSelected}
-                  className="absolute top-0 right-0"
+                  className="absolute -top-4 -right-4"
                 />
               </div>
             );

--- a/src/pages/signup/SignupPage.tsx
+++ b/src/pages/signup/SignupPage.tsx
@@ -25,7 +25,7 @@ const SignupPage: React.FC = () => {
     console.log("회원가입 요청 성공:", { email, password });
 
     // 3. 페이지 이동 (온보딩 페이지로)
-    navigate("/onboarding1"); 
+    navigate("/onboardingPage1"); 
   };
 
   return (

--- a/src/routes/route.tsx
+++ b/src/routes/route.tsx
@@ -4,6 +4,8 @@ import OnboardingLandingPage from "@/pages/onboarding/OnboardingLandingPage";
 import LoginPage from "@/pages/login/LoginPage";
 import SignupPage from "@/pages/signup/SignupPage";
 import SignupCelebrate from "@/pages/onboarding/SignupCelebrate";
+import OnboardingPage1 from "@/pages/onboarding/OnboardingPage1";
+import OnboardingPage2 from "@/pages/onboarding/OnboardingPage2";
 
 export const router = createBrowserRouter([
   {
@@ -25,5 +27,13 @@ export const router = createBrowserRouter([
   {
     path: "/signupCelebrate",
     element: <SignupCelebrate />,
-  }
+  },
+  {
+    path: "/onboardingPage1",
+    element: <OnboardingPage1 />,
+  },
+  {
+    path: "/onboardingPage2",
+    element: <OnboardingPage2 />,
+  },
 ]);

--- a/src/store/useOnboardingStore.ts
+++ b/src/store/useOnboardingStore.ts
@@ -1,0 +1,41 @@
+import { create } from 'zustand';
+
+interface OnboardingState {
+  selectedBookIds: number[]; // 선택된 책 ID들
+  toggleBookSelect: (id: number) => void; // 책 선택/해제 함수
+
+  // 닉네임 관련
+  nickname: string;
+  setNickname: (name: string) => void;
+}
+
+export const useOnboardingStore = create<OnboardingState>((set) => ({
+  selectedBookIds: [], // 처음엔 빈 배열
+
+  toggleBookSelect: (bookId) =>
+    set((state) => {
+      const isSelected = state.selectedBookIds.includes(bookId);
+      const MAX_SELECTION = 5;
+
+      // 책 선택 1. 이미 선택된 거면 뺀다 (filter)
+      if (isSelected) {
+        return {
+          selectedBookIds: state.selectedBookIds.filter((id) => id !== bookId),
+        };
+      }
+
+      // 책 선택 2. 5개 꽉 찼으면 더 이상 추가 안 함
+      if (state.selectedBookIds.length >= MAX_SELECTION) {
+        return state; // 변화 없음
+      }
+
+      // 책 선택 3. 새로 추가
+      return {
+        selectedBookIds: [...state.selectedBookIds, bookId],
+      };
+    }),
+
+    // 닉네임: 초기값 및 함수
+    nickname: "", 
+    setNickname: (name) => set({ nickname: name }),
+}));


### PR DESCRIPTION
## 📝 작업 내용

- 닉네임 입력 페이지 구현 (OnboardingPage1.tsx)
- 책 선택 페이지 구현 (OnboardingPage2.tsx)
- npm install zustand 후 store에서 상태 관리 적용 (useOnboardingStore.ts)
- 뱃지 컴포넌트(Badge.tsx) 체크 뱃지 크기 수정

## 📸 스크린샷

https://github.com/user-attachments/assets/175672b8-eada-4d51-8423-407e7bdb34a0

## 📢 발생한 이슈

## ✨ 리뷰어에게

Zustand store에서 상태 관리 이렇게 하는 방향이 맞나요? (데이터를 페이지 바깥에 있는 전역 저장소(Store)에 저장해서 페이지가 바뀌어도, 데이터 그대로 유지되도록 하ㄴ는?)

## 🔗 관련 이슈

- closed #34 