### PR TITLE
[Feat] 같이 읽기 카드 컴포넌트

### DIFF
--- a/src/components/common/cards/TogetherReadCard.tsx
+++ b/src/components/common/cards/TogetherReadCard.tsx
@@ -1,0 +1,159 @@
+import React, { useEffect, useState } from "react";
+import {Image} from '@/components'
+
+type TogetherReadCardProps = {
+  title: string;
+  participants: number;
+  remainDays: number;
+  isJoined: boolean;
+  progress?: number;
+  rank?: number;
+  thumbnailUrl?: string;
+  onClick?: () => void;
+};
+
+const TogetherReadCard: React.FC<TogetherReadCardProps> = ({
+  title,
+  participants,
+  remainDays,
+  isJoined,
+  progress = 0,
+  rank,
+  thumbnailUrl,
+  onClick,
+}) => {
+  const [animatedProgress, setAnimatedProgress] = useState(0);
+
+  useEffect(() => {
+    if (isJoined) {
+      const timer = setTimeout(() => {
+        setAnimatedProgress(progress);
+      }, 100);
+      return () => clearTimeout(timer);
+    } else {
+      setAnimatedProgress(0);
+    }
+  }, [isJoined, progress]);
+
+  return (
+    <div className="w-full rounded-[8px] bg-beige2 p-7">
+      <div className="flex items-center justify-between gap-4">
+        {/* 썸네일 */}
+        {!isJoined && (
+          <div className="h-22 w-16 flex-shrink-0">
+            <Image
+              src={thumbnailUrl}
+              alt="책 표지"
+              aspectRatio="aspect-square"
+              className="h-full w-full"
+            />
+          </div>
+        )}
+
+        {/* 텍스트 영역 */}
+        <div className="flex flex-1 flex-col gap-[5px]">
+          <p className="text-caption4 text-gray3">3주 동안 함께 읽는 책</p>
+          <h3 className="text-title6">{title}</h3>
+
+          <p className="text-caption4 text-gray3">
+            남은 기간 <span className="text-green1">D-{remainDays}</span> ·
+            참여자 <span className="text-green1">{participants}명</span>
+          </p>
+
+          {isJoined ? (
+            <p className="text-caption4">참여자 중 {rank}번째로 많이 읽었어요</p>
+          ) : (
+            <p className="text-caption4 text-gray3">아직 참여하지 않았어요</p>
+          )}
+        </div>
+
+        <div className="flex-shrink-0">
+          {isJoined ? (
+            <CircleProgress percent={animatedProgress} />
+          ) : (
+            <CircleNotJoined />
+          )}
+        </div>
+      </div>
+
+      {/* 버튼 */}
+      <div className="mt-5 flex justify-center">
+        <button className="cursor-pointer bg-green1 btn-text-white text-caption5 h-7.5 px-10 rounded-2xl" onClick={onClick}>
+          {isJoined ? "함께 읽기 방으로" : "함께 읽기 참여하기"}
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default TogetherReadCard;
+
+
+const CircleProgress = ({ percent }: { percent: number }) => {
+  const [animatedPercent, setAnimatedPercent] = useState(0);
+
+  useEffect(() => {
+    let frameId: number;
+    const duration = 600;
+    const start = performance.now();
+    const startVal = animatedPercent;
+    const diff = percent - startVal;
+
+    const tick = (now: number) => {
+      const elapsed = now - start;
+      const t = Math.min(1, elapsed / duration);
+      const next = startVal + diff * t;
+      setAnimatedPercent(next);
+
+      if (t < 1) {
+        frameId = requestAnimationFrame(tick);
+      }
+    };
+
+    frameId = requestAnimationFrame(tick);
+
+    return () => cancelAnimationFrame(frameId);
+  }, [percent]);
+
+  const clamped = Math.max(0, Math.min(100, animatedPercent));
+
+  const backgroundImage = `conic-gradient(
+    var(--color-green1) 0% ${clamped}%,
+    var(--color-gray1) ${clamped}% 100%
+  )`;
+
+  return (
+    <div className="flex items-center justify-center">
+      <div
+        className="flex h-20 w-20 items-center justify-center rounded-full"
+        style={{ backgroundImage }}
+      >
+        <div className="flex h-14 w-14 items-center justify-center rounded-full bg-beige2">
+          <span className="text-body1 text-green1">
+            {Math.round(clamped)}%
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+
+const CircleNotJoined = () => {
+  const backgroundImage = `conic-gradient(
+    var(--color-gray1) 0% 100%
+  )`;
+
+  return (
+    <div className="flex items-center justify-center">
+      <div
+        className="flex h-20 w-20 items-center justify-center rounded-full"
+        style={{ backgroundImage }}
+      >
+        <div className="flex h-14 w-14 items-center justify-center rounded-full bg-beige2">
+          <span className="text-caption4 text-gray3">미참여</span>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/pages/main/Homepage.tsx
+++ b/src/pages/main/Homepage.tsx
@@ -1,7 +1,29 @@
+import TogetherReadCard from "@/components/common/cards/TogetherReadCard";
+
 const HomePage = () => {
+  const joined = true;
+
   return (
-    <div className="w-full h-screen flex items-center justify-center bg-beige1">
-      <h1 className="text-title3 text-black">홈페이지</h1>
+    <div className="p-4 space-y-6">
+      {/* 참여 전 카드 */}
+      <TogetherReadCard
+        title="책 제목 어쩌고 저쩌고"
+        participants={27}
+        remainDays={11}
+        isJoined={false}
+        onClick={() => console.log("참여하기 버튼 클릭")}
+      />
+
+      {/* 참여 후 카드 */}
+      <TogetherReadCard
+        title="책 제목 어쩌고 저쩌고"
+        participants={27}
+        remainDays={11}
+        isJoined={true}
+        progress={33}
+        rank={2}
+        onClick={() => console.log("방으로 이동")}
+      />
     </div>
   );
 };

--- a/src/pages/main/Homepage.tsx
+++ b/src/pages/main/Homepage.tsx
@@ -1,7 +1,6 @@
 import TogetherReadCard from "@/components/common/cards/TogetherReadCard";
 
 const HomePage = () => {
-  const joined = true;
 
   return (
     <div className="p-4 space-y-6">


### PR DESCRIPTION
## 📝 작업 내용

- 같이 읽기 카드 컴포넌트 UI 구현을 완료했습니다.
- isJoined를 boolean으로 받고 true라면 참여 시 UI, false라면 미참여 시의 UI를 렌더링하도록 구현하였습니다
- 퍼센트 컴포넌트에 간단한 애니메이션을 넣었습니다.

## 📸 스크린샷 (선택)
<img width="762" height="708" alt="image" src="https://github.com/user-attachments/assets/7b62ff0f-0aaa-4000-bb2d-d1fe256942b0" />

## 📢 발생한 이슈

## ✨ 리뷰어에게
카드 컴포넌트 테스트를 하느라 HomePage에 코드를 넣어두었는데 추후 홈 UI 구현하면서 수정하도록 하겠습니다.

## 🔗 관련 이슈

- closed #42 