### PR TITLE
[Feat] 마이페이지 콘텐츠 페이지 구현

### DIFF
--- a/src/_mocks/myContentMock.ts
+++ b/src/_mocks/myContentMock.ts
@@ -1,0 +1,43 @@
+export type MyDiscussion = {
+  id: number;
+  bookTitle: string;
+  title: string;
+  content: string;
+  nickname: string;
+  dateLabel: string;
+  likeCount: number;
+  commentCount: number;
+};
+
+export type MyQuote = {
+  id: number;
+  bookTitle: string;
+  content: string;
+  tags: string[];
+  nickname: string;
+  dateLabel: string;
+  likeCount: number;
+};
+
+// 내가 작성한 토론 Mock Data
+export const myDiscussionsMock: MyDiscussion[] = Array.from({ length: 10 }).map((_, i) => ({
+  id: i + 1,
+  bookTitle: `책 제목 ${i + 1}`,
+  title: `내가 쓴 토론 제목 ${i + 1}`,
+  content: `이 책의 결말에 대해 어떻게 생각하시나요? 저는 개인적으로... (더미 텍스트) ${i + 1}`,
+  nickname: '가나디', // 내 닉네임
+  dateLabel: '25.11.03',
+  likeCount: 10 + i,
+  commentCount: 5 + i,
+}));
+
+// 내가 작성한 인용구 Mock Data
+export const myQuotesMock: MyQuote[] = Array.from({ length: 10 }).map((_, i) => ({
+  id: i + 1,
+  bookTitle: `책 제목 ${i + 1}`,
+  content: `“인상 깊은 구절입니다. 삶은 계란이다.” ${i + 1}`,
+  tags: ['인생', '철학'],
+  nickname: '체크메이트',
+  dateLabel: '25.11.04',
+  likeCount: 20 + i,
+}));

--- a/src/_mocks/myLikedContentMock.ts
+++ b/src/_mocks/myLikedContentMock.ts
@@ -1,0 +1,43 @@
+export type LikedDiscussion = {
+  id: number;
+  bookTitle: string;
+  title: string;
+  content: string;
+  nickname: string;
+  dateLabel: string;
+  likeCount: number;
+  commentCount: number;
+};
+
+export type LikedQuote = {
+  id: number;
+  bookTitle: string;
+  content: string;
+  tags: string[];
+  nickname: string;
+  dateLabel: string;
+  likeCount: number;
+};
+
+// 내가 좋아요 한 토론 Mock Data
+export const likedDiscussionsMock: LikedDiscussion[] = Array.from({ length: 12 }).map((_, i) => ({
+  id: i + 1,
+  bookTitle: `좋아요 한 책 ${i + 1}`,
+  title: `정말 공감가는 토론 주제입니다 ${i + 1}`,
+  content: `저도 이 부분에 대해서 깊게 고민해봤는데요, 작성자님 의견에 전적으로 동의합니다. 특히... (더미 텍스트)`,
+  nickname: `다른유저${i}`,
+  dateLabel: '25.11.01',
+  likeCount: 150 + i,
+  commentCount: 30 + i,
+}));
+
+// 내가 좋아요 한 인용구 Mock Data
+export const likedQuotesMock: LikedQuote[] = Array.from({ length: 12 }).map((_, i) => ({
+  id: i + 1,
+  bookTitle: `인상 깊은 책 ${i + 1}`,
+  content: `“사랑은 마주 보는 것이 아니라, 함께 같은 방향을 보는 것이다.” ${i + 1}`,
+  tags: ['사랑', '명언'],
+  nickname: `명언제조기${i}`,
+  dateLabel: '25.10.20',
+  likeCount: 300 + i,
+}));

--- a/src/components/common/cards/ListCard.tsx
+++ b/src/components/common/cards/ListCard.tsx
@@ -17,6 +17,11 @@ interface DiscussionCardProps {
   commentCount?: number;
   className?: string;
   onClickCard?: () => void;
+
+  // (추가) 좋아요 상태 강제 주입 (선택 사항)
+  isLiked?: boolean;
+  // (추가) 좋아요 버튼 클릭 시 부모에게 알림 (삭제용)
+  onLikeClick?: () => void;
 }
 
 const DiscussionCard: React.FC<DiscussionCardProps> = ({
@@ -31,16 +36,31 @@ const DiscussionCard: React.FC<DiscussionCardProps> = ({
   commentCount,
   className,
   onClickCard,
+  isLiked,     // 추가
+  onLikeClick, // 추가
 }) => {
   const isQuote = type === 'quote';
 
   // 좋아요 상태
-  const [liked, setLiked] = useState(false);
-  const displayLikeCount = likeCount + (liked ? 1 : 0);
+  //const [liked, setLiked] = useState(false);
+
+  // (수정) isLiked 값이 있으면 그걸로 초기화, 없으면 false
+  const [liked, setLiked] = useState(isLiked ?? false);
+
+  // const displayLikeCount = likeCount + (liked ? 1 : 0);
+  const displayLikeCount = likeCount + (liked ? 0 : 0); 
+  // (참고: 이미 좋아요 된 상태라면 카운트 표시는 백엔드 로직에 따라 +1/-1 달라질 수 있음. 일단 UI 위주로)
 
   const toggleLike = (e: React.MouseEvent) => {
     e.stopPropagation();
+
+    // 1. 내부 상태 변경
     setLiked((prev) => !prev);
+
+    // 2. 부모에게 알림 (MyLike 페이지에서 삭제하기 위해)
+    if (onLikeClick) {
+      onLikeClick();
+    }
   };
 
   return (

--- a/src/components/common/header/Header.tsx
+++ b/src/components/common/header/Header.tsx
@@ -86,7 +86,12 @@ const Header = ({
   // =========================
   const renderCenter = () => {
     if (variant === 'backTitle' || variant === 'backTitleDropdown') {
-      return <h1 className="text-title4">{title}</h1>;
+      return (
+        // (수정) whitespace-nowrap: 줄바꿈 금지, text-ellipsis: 넘치면 ... 처리
+        <h1 className="text-title4 whitespace-nowrap overflow-hidden text-ellipsis px-2">
+          {title}
+        </h1>
+      );
     }
     return null;
   };
@@ -146,11 +151,20 @@ const Header = ({
     <header className={cn(bgClass, 'mx-auto flex w-full max-w-[430px] flex-col', className)}>
       {/* 1줄째: 기본 헤더 라인 */}
       <div className="flex h-14 items-center justify-between px-4">
-        {' '}
-        {/* 수정 h-14에서 24*/}
-        <div className="flex flex-[0.8] items-center">{renderLeft()}</div>
-        <div className="flex flex-[1.2] justify-center">{renderCenter()}</div>
-        <div className="flex flex-[0.8] items-center justify-end">{renderRight()}</div>
+        {/* (수정) flex 비율 조정 및 min-w 설정으로 찌그러짐 방지 */}
+        <div className="flex w-10 min-w-10 items-center justify-start">
+            {renderLeft()}
+        </div>
+        
+        {/* 중앙 영역은 남는 공간 다 차지하되(flex-1), 넘치면 숨김 */}
+        <div className="flex flex-1 items-center justify-center overflow-hidden">
+            {renderCenter()}
+        </div>
+        
+        {/* 오른쪽 영역도 고정 너비로 잡아줘서 중앙 정렬이 틀어지지 않게 함 */}
+        <div className="flex w-10 min-w-10 items-center justify-end">
+            {renderRight()}
+        </div>
       </div>
 
       {/* 2줄째: VS 토론 헤더에서만 드롭다운 아이콘 (오른쪽 아래) */}

--- a/src/components/common/toggle/ToggleTab.tsx
+++ b/src/components/common/toggle/ToggleTab.tsx
@@ -8,15 +8,19 @@ const ToggleTab = ({ options, selected, onSelect, variant }: ToggleTabProps) => 
   // 1. pill 토글
   // ========================
   if (variant === 'pill') {
-    const SLIDER_WIDTH = 132;
+    // 전체 컨테이너 너비와 슬라이더 너비 정의
+    const CONTAINER_WIDTH = 335; 
+    const SLIDER_WIDTH = 152;    
     const SIDE_PADDING = 8;
 
-    const sliderLeft = selectedIndex === 0 ? SIDE_PADDING : 295 - SLIDER_WIDTH - SIDE_PADDING; // 오른쪽 탭일 때 위치
-
+    const sliderLeft = selectedIndex === 0 
+          ? SIDE_PADDING 
+          : CONTAINER_WIDTH - SLIDER_WIDTH - SIDE_PADDING; 
     return (
       <div className="flex justify-center">
         <div
-          className={cn('relative h-[49px] w-[295px]', 'rounded-m bg-green1', 'overflow-hidden')}
+          className={cn('relative h-[49px]', 'rounded-m bg-green1', 'overflow-hidden')}
+          style={{ width: `${CONTAINER_WIDTH}px` }}
         >
           {/* 흰색 슬라이더 */}
           <div

--- a/src/pages/mypage/MyLiked.tsx
+++ b/src/pages/mypage/MyLiked.tsx
@@ -1,0 +1,153 @@
+import React, { useState, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { Header, ToggleTab, Toast } from '@/components';
+import DiscussionCard from '@/components/common/cards/ListCard'; 
+import { likedDiscussionsMock, likedQuotesMock } from '@/_mocks/myLikedContentMock';
+import { cn } from '@/utils/cn';
+
+type Tab = '인용구' | '토론';
+
+const MyLiked: React.FC = () => {
+  const navigate = useNavigate();
+  const [activeTab, setActiveTab] = useState<Tab>('인용구');
+
+  // 1. Mock Data를 State로 변환 (삭제 시 리렌더링을 위해)
+  const [quotes, setQuotes] = useState(likedQuotesMock);
+  const [discussions, setDiscussions] = useState(likedDiscussionsMock);
+
+  // 2. 삭제 애니메이션 및 토스트 상태 관리
+  const [leavingId, setLeavingId] = useState<number | null>(null);
+  const [toastVisible, setToastVisible] = useState(false);
+
+  // 3. 좋아요 취소 핸들러 (DiscussionCard의 onLikeClick에서 호출)
+  const handleUnlike = (id: number, type: 'quote' | 'discussion') => {
+    // (1) 애니메이션 시작: 카드가 옆으로 밀려남
+    setLeavingId(id);
+
+    // (2) 0.3초(애니메이션 시간) 뒤에 실제 데이터 삭제
+    setTimeout(() => {
+      if (type === 'quote') {
+        setQuotes((prev) => prev.filter((q) => q.id !== id));
+      } else {
+        setDiscussions((prev) => prev.filter((d) => d.id !== id));
+      }
+      setLeavingId(null); // 상태 초기화
+      setToastVisible(true); // "삭제되었습니다" 토스트 표시
+    }, 300);
+  };
+
+  // 토스트 자동 숨김 타이머
+  useEffect(() => {
+    if (toastVisible) {
+      const timer = setTimeout(() => setToastVisible(false), 2000);
+      return () => clearTimeout(timer);
+    }
+  }, [toastVisible]);
+
+  return (
+    <div className="bg-beige1 min-h-screen w-full relative overflow-x-hidden">
+      <Header
+        variant="backTitle"
+        title="내가 좋아요 한 콘텐츠"
+        onBackClick={() => navigate(-1)}
+        className="sticky top-0 z-50 bg-beige1"
+      />
+
+      <main className="w-full pb-20">
+        <section className="px-5 py-4">
+          <ToggleTab
+            variant="pill"
+            options={['인용구', '토론']}
+            selected={activeTab}
+            onSelect={(option) => setActiveTab(option as Tab)}
+          />
+        </section>
+
+        <section className="px-5 space-y-3">
+          
+          {/* (A) 인용구 리스트 */}
+          {activeTab === '인용구' && (
+            <>
+              {quotes.length === 0 ? (
+                <div className="flex h-[50vh] items-center justify-center text-body3 text-gray3">
+                  좋아요 한 인용구가 없습니다.
+                </div>
+              ) : (
+                quotes.map((q) => (
+                  <DiscussionCard
+                    key={q.id}
+                    type="quote"
+                    isLiked={true} // 좋아요 목록이므로 true로 시작
+                    onLikeClick={() => handleUnlike(q.id, 'quote')} 
+                    
+                    bookTitle={q.bookTitle}
+                    content={q.content}
+                    tags={q.tags}
+                    nickname={q.nickname}
+                    dateLabel={q.dateLabel}
+                    likeCount={q.likeCount}
+                    onClickCard={() => console.log(`인용구 ${q.id} 상세 이동`)}
+                    
+                    // 삭제 애니메이션 클래스 적용
+                    className={cn(
+                      "transition-all duration-300 ease-out",
+                      leavingId === q.id 
+                        ? "translate-x-full opacity-0" 
+                        : "translate-x-0 opacity-100"
+                    )}
+                  />
+                ))
+              )}
+            </>
+          )}
+
+          {/* (B) 토론 리스트 */}
+          {activeTab === '토론' && (
+            <>
+              {discussions.length === 0 ? (
+                <div className="flex h-[50vh] items-center justify-center text-body3 text-gray3">
+                  좋아요 한 토론이 없습니다.
+                </div>
+              ) : (
+                discussions.map((d) => (
+                  <DiscussionCard
+                    key={d.id}
+                    type="discussion"
+                    isLiked={true} // 좋아요 목록이므로 true로 시작
+                    onLikeClick={() => handleUnlike(d.id, 'discussion')} // 하트 클릭 시 handleUnlike 실행
+                    
+                    bookTitle={d.bookTitle}
+                    title={d.title}
+                    content={d.content}
+                    nickname={d.nickname}
+                    dateLabel={d.dateLabel}
+                    likeCount={d.likeCount}
+                    commentCount={d.commentCount}
+                    onClickCard={() => console.log(`토론 ${d.id} 상세 이동`)}
+                    
+                    // 삭제 애니메이션 클래스 적용
+                    className={cn(
+                      "transition-all duration-300 ease-out",
+                      leavingId === d.id 
+                        ? "translate-x-full opacity-0" 
+                        : "translate-x-0 opacity-100"
+                    )}
+                  />
+                ))
+              )}
+            </>
+          )}
+        </section>
+      </main>
+
+      {/* 삭제 알림 토스트 */}
+      <Toast 
+        variant="alert"
+        visible={toastVisible}
+        message="목록에서 삭제되었습니다"
+      />
+    </div>
+  );
+};
+
+export default MyLiked;

--- a/src/pages/mypage/MyWrite.tsx
+++ b/src/pages/mypage/MyWrite.tsx
@@ -1,0 +1,103 @@
+import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { Header, ToggleTab, DiscussionCard } from '@/components';
+import { myDiscussionsMock, myQuotesMock } from '@/_mocks/myContentMock';
+
+// 탭 타입 정의
+type Tab = '인용구' | '토론';
+
+const MyWrite: React.FC = () => {
+  const navigate = useNavigate();
+  
+  // 1. 탭 상태 관리 (기본값: 인용구)
+  const [activeTab, setActiveTab] = useState<Tab>('인용구');
+
+  // 2. 현재 탭에 맞는 데이터 가져오기
+  // (나중에 API가 생기면 useEffect로 activeTab 바뀔 때마다 fetch)
+  const discussions = myDiscussionsMock;
+  const quotes = myQuotesMock;
+
+  return (
+    <div className="bg-beige1 min-h-screen w-full relative">
+      {/* 1. 헤더 */}
+      <Header
+        variant="backTitle"
+        title="내가 작성한 콘텐츠"
+        onBackClick={() => navigate(-1)}
+        className="sticky top-0 z-50 bg-beige1"
+      />
+
+      <main className="w-full pb-20">
+        {/* 2. 토글 탭 영역 */}
+        <section className="px-5 py-4">
+          <ToggleTab
+            variant="pill"
+            options={['인용구', '토론']}
+            selected={activeTab}
+            onSelect={(option) => setActiveTab(option as Tab)}
+          />
+        </section>
+
+        {/* 3. 콘텐츠 리스트 영역 */}
+        <section className="px-5 space-y-3">
+          
+          {/* (A) 인용구 리스트 */}
+          {activeTab === '인용구' && (
+            <>
+              {quotes.length === 0 ? (
+                <div className="text-body3 text-gray3 mt-10 text-center">
+                  작성한 인용구가 없습니다.
+                </div>
+              ) : (
+                quotes.map((q) => (
+                  <DiscussionCard
+                    key={q.id}
+                    type="quote"
+                    bookTitle={q.bookTitle}
+                    content={q.content}
+                    tags={q.tags}
+                    nickname={q.nickname}
+                    dateLabel={q.dateLabel}
+                    likeCount={q.likeCount}
+                    // 인용구는 댓글 수 없음
+                    // 상세 페이지 이동 (임시)
+                    onClickCard={() => console.log(`인용구 ${q.id} 클릭`)}
+                  />
+                ))
+              )}
+            </>
+          )}
+
+          {/* (B) 토론 리스트 */}
+          {activeTab === '토론' && (
+            <>
+              {discussions.length === 0 ? (
+                <div className="text-body3 text-gray3 mt-10 text-center">
+                  작성한 토론이 없습니다.
+                </div>
+              ) : (
+                discussions.map((d) => (
+                  <DiscussionCard
+                    key={d.id}
+                    type="discussion"
+                    bookTitle={d.bookTitle}
+                    title={d.title}
+                    content={d.content}
+                    nickname={d.nickname}
+                    dateLabel={d.dateLabel}
+                    likeCount={d.likeCount}
+                    commentCount={d.commentCount}
+                    // 상세 페이지 이동 (임시)
+                    onClickCard={() => console.log(`토론 ${d.id} 클릭`)}
+                  />
+                ))
+              )}
+            </>
+          )}
+        </section>
+      </main>
+    </div>
+  );
+};
+
+export default MyWrite;

--- a/src/pages/mypage/Mypage.tsx
+++ b/src/pages/mypage/Mypage.tsx
@@ -149,7 +149,7 @@ const MyPage: React.FC = () => {
           <button 
             type="button"
             className="flex items-center gap-1 w-fit py-1 cursor-pointer"
-            onClick={() => navigate('/my-content')} //추후 경로 수정
+            onClick={() => navigate('/mypage/mywrite')} //내가 작성한 콘텐츠로 이동
           >
              <h3 className="text-title4 text-black">내가 작성한 콘텐츠</h3>
              <RightArrowIcon className="w-8 h-8 text-black" />
@@ -158,7 +158,7 @@ const MyPage: React.FC = () => {
           <button 
             type="button"
             className="flex items-center gap-1 w-fit cursor-pointer"
-            onClick={() => navigate('/my-liked-content')} //추후 경로 수정
+            onClick={() => navigate('/mypage/myliked')} //내가 좋아요 한 콘텐츠로 이동
           >
              <h3 className="text-title4 text-black">내가 좋아요 한 콘텐츠</h3>
              <RightArrowIcon className="w-8 h-8 text-black" />

--- a/src/routes/route.tsx
+++ b/src/routes/route.tsx
@@ -13,6 +13,8 @@ import OnboardingPage4 from '@/pages/onboarding/OnboardingPage4';
 import Mypage from '@/pages/mypage/Mypage';
 import MyBook from '@/pages/mypage/MyBook';
 import Setting from '@/pages/mypage/Setting';
+import MyWrite from '@/pages/mypage/MyWrite';
+import MyLiked from '@/pages/mypage/MyLiked';
 
 export const router = createBrowserRouter([
   {
@@ -71,4 +73,13 @@ export const router = createBrowserRouter([
     path: '/mypage/setting',
     element: <Setting />,
   },
+  {
+    path: '/mypage/mywrite',
+    element: <MyWrite />,
+  },
+  {
+    path: '/mypage/myliked',
+    element: <MyLiked />,
+  },
+
 ]);


### PR DESCRIPTION
## 📝 작업 내용

- 내가 작성한 콘텐츠 페이지 구현 (MyWrite.tsx)
- 내가 좋아요 한 콘텐츠 페이지 구현 (MyLiked.tsx)
- 묵데이터로 테스트
- 헤더 중앙 텍스트가 길어지면 줄바꿈이 일어나는 문제가 있어서 헤더 컴포넌트 약간 수정
- 내가 좋아요 한 콘텐츠 페이지에서 좋아요 버튼이 디폴트로 눌려져 있어야 해서, 카드 컴포넌트(ListCard.tsx)를 외부에서 "좋아요 상태"를 주입받을 수 있게 수정 (isLiked prop 추가)
- 각 카드를 누르면 토론이나 인용구 상세페이지로 넘어가는 것은 구현하지 않았습니다.....

## 📸 스크린샷

https://github.com/user-attachments/assets/3a113f56-842c-44dc-b6e7-48cf413331da

## 📢 발생한 이슈

## ✨ 리뷰어에게

카드컴포넌트 수정 방향:
isLiked라는 옵션을 받아서, 있으면 그 값으로 시작하고, 없으면 기존처럼 false로 시작하도록 했습니다.
isLiked={true} 를 줘서 무조건 하트가 채워진 상태가 되도록.
그리고 데이터를 useState로 관리하고, 하트 취소 시 목록에서 삭제되도록 하였습니다!
(내가 좋아요 한 페이지에서 하트 클릭 시 handleUnlike가 실행되어 목록에서 삭제)
추후 handleUnlike에 API 호출되어 데이터 삭제되도록 할 수 있을 것 같...습니다(? 아마


## 🔗 관련 이슈

- closed #48 