### PR TITLE
[Feat] 메인 페이지 구현

### DIFF
--- a/src/_mocks/mainPageMock.ts
+++ b/src/_mocks/mainPageMock.ts
@@ -1,0 +1,153 @@
+// ===== 함께 읽기 세션 =====
+export type TogetherReadSession = {
+  id: number;
+  title: string;
+  participants: number;
+  remainDays: number;
+  isJoined: boolean;
+  progress?: number;
+  rank?: number;
+  thumbnailUrl?: string;
+};
+
+// ===== 책 카드 =====
+export type MainPageBook = {
+  id: number;
+  title: string;
+  coverUrl: string;
+};
+
+// ===== AI 추천 / 인기 도서 목업 =====
+export const MOCK_MAIN_BOOKS: MainPageBook[] = [
+  {
+    id: 1,
+    title: "책 제목 1",
+    coverUrl: "https://via.placeholder.com/150",
+  },
+  {
+    id: 2,
+    title: "책 제목 2",
+    coverUrl: "https://via.placeholder.com/150",
+  },
+  {
+    id: 3,
+    title: "책 제목 3",
+    coverUrl: "https://via.placeholder.com/150",
+  },
+  {
+    id: 4,
+    title: "책 제목 4",
+    coverUrl: "https://via.placeholder.com/150",
+  },
+  {
+    id: 5,
+    title: "책 제목 5",
+    coverUrl: "",
+  },
+  {
+    id: 6,
+    title: "책 제목 6",
+    coverUrl: "",
+  },
+];
+
+// ===== 함께 읽기 =====
+export const MOCK_TOGETHER_READ: TogetherReadSession | null = {
+  id: 1,
+  title: "고대 도의 아틀란티스",
+  participants: 27,
+  remainDays: 11,
+  isJoined: true,
+  progress: 33,
+  rank: 3,
+  thumbnailUrl:
+    "https://images.unsplash.com/photo-1544937950-fa07a98d237f?auto=format&fit=crop&w=400&q=80",
+};
+
+// ===== 뜨거운 토론장 카드 =====
+export type HotDiscussion = {
+  id: number;
+  bookTitle: string;
+  title: string;
+  content: string;
+  nickname: string;
+  dateLabel: string;
+  likeCount: number;
+  commentCount: number;
+};
+
+export const MOCK_HOT_DISCUSSIONS: HotDiscussion[] = [
+  {
+    id: 101,
+    bookTitle: "책 제목 1",
+    title: "토론 제목 1",
+    content:
+      "토론 상세 내용 어쩌고 저쩌고 이렇게 길게 만들까?? 근데 얼마나 길게해야 되는지...",
+    nickname: "닉네임1",
+    dateLabel: "25.11.03",
+    likeCount: 24,
+    commentCount: 24,
+  },
+  {
+    id: 102,
+    bookTitle: "책 제목 2",
+    title: "토론 제목 2",
+    content: "두 번째 토론 내용입니다. 어디까지 깊게 파야 할까요?",
+    nickname: "닉네임2",
+    dateLabel: "25.11.04",
+    likeCount: 12,
+    commentCount: 7,
+  },
+  {
+    id: 3,
+    bookTitle: "책 제목 3",
+    title: "토론 제목 3",
+    content: "결말에 대한 해석이 너무 달라서 재밌었던 토론이에요.",
+    nickname: "닉네임3",
+    dateLabel: "25.11.05",
+    likeCount: 30,
+    commentCount: 15,
+  },
+];
+
+// ===== 나를 위한 인용구 카드 =====
+export type RecommendedQuote = {
+  id: number;
+  bookTitle: string;
+  content: string;
+  tags: string[];
+  nickname: string;
+  dateLabel: string;
+  likeCount: number;
+};
+
+export const MOCK_RECOMMENDED_QUOTES: RecommendedQuote[] = [
+  {
+    id: 1,
+    bookTitle: "책 제목 1",
+    content:
+      "인용구 이렇게 어쩌고 저쩌고 길어지면 두 줄까지 허용해야 되는건가??? ...",
+    tags: ["태그1", "태그2"],
+    nickname: "닉네임1",
+    dateLabel: "25.11.03",
+    likeCount: 24,
+  },
+  {
+    id: 2,
+    bookTitle: "책 제목 2",
+    content: "오늘 하루를 버티게 해주는 문장이었다고 느꼈던 구절이에요.",
+    tags: ["위로", "힐링"],
+    nickname: "닉네임2",
+    dateLabel: "25.11.04",
+    likeCount: 18,
+  },
+  {
+    id: 3,
+    bookTitle: "책 제목 3",
+    content: "다음 페이지를 넘기기 전에 꼭 한 번 더 읽게 되는 문장.",
+    tags: ["명대사"],
+    nickname: "닉네임3",
+    dateLabel: "25.11.05",
+    likeCount: 32,
+  },
+];

--- a/src/components/common/Scroll/CardCarousel.tsx
+++ b/src/components/common/Scroll/CardCarousel.tsx
@@ -1,0 +1,66 @@
+import React, { useRef, useState, type UIEvent } from "react";
+import { cn } from "@/utils/cn";
+
+interface CardCarouselProps {
+  children: React.ReactNode;
+  className?: string;
+  showDots?: boolean;
+}
+
+const CardCarousel: React.FC<CardCarouselProps> = ({
+  children,
+  className,
+  showDots = true,
+}) => {
+  const scrollRef = useRef<HTMLDivElement | null>(null);
+  const [currentIndex, setCurrentIndex] = useState(0);
+
+  const total = React.Children.count(children);
+
+  const handleScroll = (e: UIEvent<HTMLDivElement>) => {
+    const target = e.currentTarget;
+    const { scrollLeft, clientWidth } = target;
+
+    const index = Math.round(scrollLeft / clientWidth);
+    setCurrentIndex(index);
+  };
+
+  return (
+    <div className={cn("w-full px-5", className)}>
+      <div
+        ref={scrollRef}
+        onScroll={handleScroll}
+        className={cn(
+          "flex overflow-x-auto scrollbar-hidden",
+          "snap-x snap-mandatory pb-2"
+        )}
+      >
+        {React.Children.map(children, (child, i) => (
+          <div
+            key={i}
+            className="snap-start flex-shrink-0 py-1 px-1 w-full pr-4"
+          >
+            {child}
+          </div>
+        ))}
+      </div>
+
+      {/* 하단 도트 인디케이터 */}
+      {showDots && total > 1 && (
+        <div className="mb-2 flex justify-center gap-1">
+          {Array.from({ length: total }).map((_, i) => (
+            <span
+              key={i}
+              className={cn(
+                "h-1.5 w-1.5 rounded-full bg-gray2",
+                i === currentIndex && "bg-gray3"
+              )}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default CardCarousel;

--- a/src/components/common/Scroll/HorizontalBookScroll.tsx
+++ b/src/components/common/Scroll/HorizontalBookScroll.tsx
@@ -13,22 +13,21 @@ const HorizontalBookScrollSection: React.FC<HorizontalBookScrollSectionProps> = 
   children,
 }) => {
   return (
-    <section className={cn("w-full bg-beige1", className)}>
+    <section className={cn("w-full px-1 bg-beige1", className)}>
       <div className="flex items-center px-5 pt-4">
-        <span className="mr-2 h-[1px] w-8 bg-black" />
-        <h2 className="text-title6 text-black">{title}</h2>
+        <h2 className="text-title5">{title}</h2>
       </div>
 
       <div className="relative mt-3 px-5 pb-3">
         <div className="scrollbar-hidden overflow-x-auto">
-          <div className="flex gap-3 pr-10">{children}</div>
+          <div className="flex gap-5 pr-10">{children}</div>
         </div>
 
         <div
           className="
             pointer-events-none
             absolute right-5 top-0
-            h-full w-14
+            h-full w-12
             bg-gradient-to-l
             from-[var(--color-beige1)]
             to-transparent

--- a/src/components/common/Scroll/HorizontalBookScroll.tsx
+++ b/src/components/common/Scroll/HorizontalBookScroll.tsx
@@ -1,0 +1,42 @@
+import React from "react";
+import { cn } from "@/utils/cn";
+
+interface HorizontalBookScrollSectionProps {
+  title: string;
+  className?: string;
+  children: React.ReactNode;
+}
+
+const HorizontalBookScrollSection: React.FC<HorizontalBookScrollSectionProps> = ({
+  title,
+  className,
+  children,
+}) => {
+  return (
+    <section className={cn("w-full bg-beige1", className)}>
+      <div className="flex items-center px-5 pt-4">
+        <span className="mr-2 h-[1px] w-8 bg-black" />
+        <h2 className="text-title6 text-black">{title}</h2>
+      </div>
+
+      <div className="relative mt-3 px-5 pb-3">
+        <div className="scrollbar-hidden overflow-x-auto">
+          <div className="flex gap-3 pr-10">{children}</div>
+        </div>
+
+        <div
+          className="
+            pointer-events-none
+            absolute right-5 top-0
+            h-full w-14
+            bg-gradient-to-l
+            from-[var(--color-beige1)]
+            to-transparent
+          "
+        />
+      </div>
+    </section>
+  );
+};
+
+export default HorizontalBookScrollSection;

--- a/src/components/common/header/Header.tsx
+++ b/src/components/common/header/Header.tsx
@@ -127,7 +127,7 @@ const Header = ({
 
       case 'logoMy':
         return (
-          <button type="button" onClick={onMyPageClick} aria-label="마이페이지">
+          <button type="button" className='cursor-pointer' onClick={onMyPageClick} aria-label="마이페이지">
             <MyPageIcon className="text-green1 h-8 w-8" />
           </button>
         );

--- a/src/components/common/image/Image.tsx
+++ b/src/components/common/image/Image.tsx
@@ -5,6 +5,7 @@ interface ImageProps extends React.ImgHTMLAttributes<HTMLImageElement> {
   className?: string;
   rounded?: string;
   aspectRatio?: string;
+  onClick?: () => void;
 }
 
 export default function Image({
@@ -12,7 +13,8 @@ export default function Image({
   alt = '',
   className,
   aspectRatio = '',
-  rounded = 'rounded-md',
+  rounded = 'rounded-[0px]',
+  onClick,
   ...props
 }: ImageProps) {
   const wrapperRef = useRef<HTMLDivElement>(null);
@@ -25,9 +27,11 @@ export default function Image({
       <div
         ref={wrapperRef}
         className={cn('bg-gray1 relative h-full w-full', aspectRatio, className)}
+        onClick={onClick}
       />
     );
   }
+
   useEffect(() => {
     const observer = new IntersectionObserver(([entry]) => {
       if (entry.isIntersecting) {
@@ -43,12 +47,19 @@ export default function Image({
   return (
     <div
       ref={wrapperRef}
-      className={cn('relative w-full overflow-hidden', aspectRatio, rounded, className)}
+      className={cn(
+        'relative w-full overflow-hidden',
+        aspectRatio,
+        rounded,
+        className,
+        onClick ? 'cursor-pointer' : ''
+      )}
+      onClick={onClick}
     >
-      {/*에러: bg-gray1*/}
+      {/* 에러: 회색 박스 */}
       {inView && error && <div className={cn('bg-gray1 h-full w-full', rounded)} />}
 
-      {/*로딩 중: blur*/}
+      {/* 이미지 로딩 */}
       {inView && !error && (
         <img
           src={src}
@@ -58,7 +69,7 @@ export default function Image({
           className={cn(
             'h-full w-full object-cover transition-all duration-500',
             rounded,
-            loaded ? 'blur-0 opacity-100' : 'opacity-70 blur-sm',
+            loaded ? 'blur-0 opacity-100' : 'opacity-70 blur-sm'
           )}
           {...props}
         />

--- a/src/components/common/search/Search.tsx
+++ b/src/components/common/search/Search.tsx
@@ -33,7 +33,7 @@ const Search = ({
   };
 
   return (
-    <div className={cn('w-full max-w-[335px]', className)}>
+    <div className={cn('w-full max-w-[430px]', className)}>
       <div className="flex h-11 items-center rounded-m border-2 border-green1 bg-beige2 px-3">
         <input
           type="text"
@@ -43,8 +43,7 @@ const Search = ({
           placeholder={placeholder}
           className={cn(
             'flex-1 bg-transparent outline-none',
-            // Body1 + 검정색, placeholder는 회색
-            'text-body1 text-black placeholder:text-gray2'
+            'text-body1 placeholder:text-gray2'
           )}
         />
 
@@ -52,7 +51,7 @@ const Search = ({
           type="button"
           onClick={handleClick}
           aria-label="검색"
-          className="ml-2 flex items-center justify-center"
+          className="ml-2 flex items-center justify-center cursor-pointer"
         >
           <SearchIcon className="w-5 h-5 text-green1" />
         </button>

--- a/src/components/index.tsx
+++ b/src/components/index.tsx
@@ -13,7 +13,10 @@ import Toast from './common/toast/Toast';
 import DiscussionCreateModal from './common/modal/DiscussionCreateModal';
 import QuoteCreateModal from './common/modal/QuoteCreateModal';
 import DebateMessageBubble from './debate/MessageBubble';
-import  DebateMessage  from './debate/MessageBubble';
+import DebateMessage from './debate/MessageBubble';
+import TogetherReadCard from './common/cards/TogetherReadCard';
+import HorizontalBookScrollSection from './common/Scroll/HorizontalBookScroll';
+import CardCarousel from './common/Scroll/CardCarousel';
 
 export {
   Button,
@@ -31,5 +34,8 @@ export {
   DiscussionCreateModal,
   QuoteCreateModal,
   DebateMessageBubble,
-  DebateMessage
+  DebateMessage,
+  TogetherReadCard,
+  HorizontalBookScrollSection,
+  CardCarousel
 };

--- a/src/hooks/useScrollDirection.ts
+++ b/src/hooks/useScrollDirection.ts
@@ -1,0 +1,26 @@
+import { useEffect, useState } from "react";
+
+export default function useScrollHide(threshold = 40) {
+  const [hidden, setHidden] = useState(false);
+
+  useEffect(() => {
+    let lastY = window.scrollY;
+
+    const onScroll = () => {
+      const y = window.scrollY;
+
+      if (y > lastY && y > threshold) {
+        setHidden(true);
+      } else if (y < lastY) {
+        setHidden(false);
+      }
+
+      lastY = y;
+    };
+
+    window.addEventListener("scroll", onScroll);
+    return () => window.removeEventListener("scroll", onScroll);
+  }, [threshold]);
+
+  return hidden;
+}

--- a/src/pages/detail/BookDetailPage.tsx
+++ b/src/pages/detail/BookDetailPage.tsx
@@ -38,9 +38,11 @@ const BookDetailPage: React.FC = () => {
 
   return (
     <div className="bg-beige1 min-h-screen">
-      <Header variant="logoBookmark" />
+      <div className="fixed left-0 right-0 top-0 z-50">
+        <Header variant="logoBookmark" />
+      </div>
 
-      <div className="mx-auto pb-10">
+      <div className="mx-auto pt-14 pb-10">
         {/* ===== 책 정보 카드 ===== */}
         <div className="bg-beige2">
           <div className="flex gap-4 px-6 pt-1 pb-5">
@@ -79,8 +81,8 @@ const BookDetailPage: React.FC = () => {
         </div>
 
         {activeTab === '토론' && (
-          <div className="mt-4 flex items-center justify-between">
-            <span className="text-body3 text-gray6" />
+          <div className="mt-4 pr-2 flex items-center justify-between">
+            <span className="text-body3" />
             <button
               type="button"
               className="text-caption2 cursor-pointer"
@@ -92,7 +94,7 @@ const BookDetailPage: React.FC = () => {
         )}
 
         {activeTab === '인용구' && (
-          <div className="mt-4 flex items-center justify-between">
+          <div className="mt-4 pr-2 flex items-center justify-between">
             <span className="text-body3" />
             <button
               type="button"
@@ -106,7 +108,7 @@ const BookDetailPage: React.FC = () => {
 
         {/* ===== 토론 리스트 ===== */}
         {activeTab === '토론' && (
-          <div className="mt-4 px-2">
+          <div className="mt-4 px-5">
             {discussions.length === 0 ? (
               <p className="text-body3 text-gray5 mt-6 text-center">아직 등록된 토론이 없어요.</p>
             ) : (
@@ -134,7 +136,7 @@ const BookDetailPage: React.FC = () => {
 
         {/* ===== 인용구 탭 ===== */}
         {activeTab === '인용구' && (
-          <div className="mt-4 space-y-3 px-2">
+          <div className="mt-4 space-y-3 px-5">
             {quotes.length === 0 ? (
               <div className="text-body3 text-gray3 mt-6 text-center">
                 아직 등록된 인용구가 없어요.

--- a/src/pages/main/Homepage.tsx
+++ b/src/pages/main/Homepage.tsx
@@ -1,30 +1,163 @@
-import TogetherReadCard from "@/components/common/cards/TogetherReadCard";
+import React, { useState } from "react";
+import {
+  Header,
+  DiscussionCard,
+  Image,
+  Search,
+  TogetherReadCard,
+  HorizontalBookScrollSection,
+  CardCarousel,
+} from "@/components";
+import { useNavigate } from "react-router-dom";
+import { cn } from "@/utils/cn";
+import useScrollHide from "@/hooks/useScrollDirection";
 
-const HomePage = () => {
+import {
+  MOCK_MAIN_BOOKS,
+  MOCK_TOGETHER_READ,
+  MOCK_HOT_DISCUSSIONS,
+  MOCK_RECOMMENDED_QUOTES,
+} from "@/_mocks/mainPageMock";
+
+const MainPage: React.FC = () => {
+  const navigate = useNavigate();
+  const togetherRead = MOCK_TOGETHER_READ; // 추후 API로 교체
+  const [keyword, setKeyword] = useState("");
+  const isHidden = useScrollHide(40);
+
+  const handleSubmit = () => {
+    console.log(`검색 요청: ${keyword || "(비어 있음)"}`);
+  };
 
   return (
-    <div className="p-4 space-y-6">
-      {/* 참여 전 카드 */}
-      <TogetherReadCard
-        title="책 제목 어쩌고 저쩌고"
-        participants={27}
-        remainDays={11}
-        isJoined={false}
-        onClick={() => console.log("참여하기 버튼 클릭")}
-      />
+    <div className="min-h-screen bg-beige1">
+      <div className="fixed left-0 right-0 top-0 z-50">
+        <Header variant="logoMy" onMyPageClick={()=>navigate('/mypage')}/>
 
-      {/* 참여 후 카드 */}
-      <TogetherReadCard
-        title="책 제목 어쩌고 저쩌고"
-        participants={27}
-        remainDays={11}
-        isJoined={true}
-        progress={33}
-        rank={2}
-        onClick={() => console.log("방으로 이동")}
-      />
+        <div
+          className={cn(
+            "flex justify-center pt-1 pb-3 transition-all duration-300 bg-beige1",
+            "origin-top",
+            isHidden
+              ? "-translate-y-full opacity-0"
+              : "translate-y-0 opacity-100"
+          )}
+        >
+          <Search
+            value={keyword}
+            onChange={setKeyword}
+            placeholder="찾고 싶은 책이 있나요?"
+            onSubmit={handleSubmit}
+            className="px-7"
+          />
+        </div>
+      </div>
+
+      {/* 헤더 + 검색창 높이 만큼 패딩 */}
+      <div className="mx-auto pb-20 pt-27">
+        {/* ===== 배너 영역 (목데이터) ===== */}
+        <div className="mt-3.5">
+          <Image className="w-full h-41"/>
+        </div>
+
+        {/* ===== 함께 읽기 섹션 ===== */}
+        {togetherRead && (
+          <section className="mt-6 px-5">
+            <h2 className="mb-4 text-title5 text-black">
+              현재 진행되고 있는 함께 읽기
+            </h2>
+
+            {/* 지금은 1개지만, 나중에 여러 개면 CardCarousel 안에 map으로 넣기 */}
+            <TogetherReadCard
+              title={togetherRead.title}
+              participants={togetherRead.participants}
+              remainDays={togetherRead.remainDays}
+              isJoined={togetherRead.isJoined}
+              progress={togetherRead.progress}
+              rank={togetherRead.rank}
+              thumbnailUrl={togetherRead.thumbnailUrl}
+              onClick={() => {
+                // TODO: 함께 읽기 상세/참여 페이지로 이동
+              }}
+            />
+          </section>
+        )}
+
+        {/* ===== AI 추천 도서 ===== */}
+        <HorizontalBookScrollSection title="님을 위한 AI 추천 도서" className="pt-8">
+          {MOCK_MAIN_BOOKS.map((b) => (
+            <div key={b.id} className="h-23 w-17 flex-shrink-0">
+              <Image
+                src={b.coverUrl}
+                alt={b.title}
+                className="h-full w-full cursor-pointer"
+                onClick={() => navigate(`/book/${b.id}`)}
+              />
+            </div>
+          ))}
+        </HorizontalBookScrollSection>
+
+        {/* ===== 체크메이트의 인기 도서 ===== */}
+        <HorizontalBookScrollSection title="체크메이트의 인기 도서" className="pt-5">
+          {MOCK_MAIN_BOOKS.map((b) => (
+            <div key={b.id} className="h-23 w-17 flex-shrink-0">
+              <Image
+                src={b.coverUrl}
+                alt={b.title}
+                className="h-full w-full"
+                onClick={() => navigate(`/book/${b.id}`)}
+              />
+            </div>
+          ))}
+        </HorizontalBookScrollSection>
+
+        {/* ===== 지금 뜨거운 토론장 (캐러셀 + 도트) ===== */}
+        <section className="mt-10">
+          <h2 className="px-5 text-title5">지금 뜨거운 토론장</h2>
+
+          <CardCarousel className="mt-3">
+            {MOCK_HOT_DISCUSSIONS.map((d) => (
+              <DiscussionCard
+                key={d.id}
+                type="discussion"
+                bookTitle={d.bookTitle}
+                title={d.title}
+                content={d.content}
+                nickname={d.nickname}
+                dateLabel={d.dateLabel}
+                likeCount={d.likeCount}
+                commentCount={d.commentCount}
+                onClickCard={() => navigate(`/debate/${d.id}`)}
+              />
+            ))}
+          </CardCarousel>
+        </section>
+
+        {/* ===== 나를 위한 인용구 (캐러셀 + 도트) ===== */}
+        <section className="mt-10">
+          <h2 className="px-5 text-title5">나를 위한 인용구</h2>
+
+          <CardCarousel className="mt-3">
+            {MOCK_RECOMMENDED_QUOTES.map((q) => (
+              <DiscussionCard
+                key={q.id}
+                type="quote"
+                bookTitle={q.bookTitle}
+                content={q.content}
+                tags={q.tags}
+                nickname={q.nickname}
+                dateLabel={q.dateLabel}
+                likeCount={q.likeCount}
+                onClickCard={() => {
+                  // TODO: 인용구 상세 모달 열기
+                }}
+              />
+            ))}
+          </CardCarousel>
+        </section>
+      </div>
     </div>
   );
 };
 
-export default HomePage;
+export default MainPage;

--- a/src/pages/main/Homepage.tsx
+++ b/src/pages/main/Homepage.tsx
@@ -36,7 +36,7 @@ const MainPage: React.FC = () => {
 
         <div
           className={cn(
-            "flex justify-center pt-1 pb-3 transition-all duration-300 bg-beige1",
+            "flex justify-center pt-1 pb-3 transition-all duration-300",
             "origin-top",
             isHidden
               ? "-translate-y-full opacity-0"

--- a/src/pages/main/Homepage.tsx
+++ b/src/pages/main/Homepage.tsx
@@ -53,21 +53,18 @@ const MainPage: React.FC = () => {
         </div>
       </div>
 
-      {/* 헤더 + 검색창 높이 만큼 패딩 */}
       <div className="mx-auto pb-20 pt-27">
-        {/* ===== 배너 영역 (목데이터) ===== */}
+        {/* ===== 배너 영역  ===== */}
         <div className="mt-3.5">
           <Image className="w-full h-41"/>
         </div>
 
-        {/* ===== 함께 읽기 섹션 ===== */}
         {togetherRead && (
           <section className="mt-6 px-5">
             <h2 className="mb-4 text-title5 text-black">
               현재 진행되고 있는 함께 읽기
             </h2>
 
-            {/* 지금은 1개지만, 나중에 여러 개면 CardCarousel 안에 map으로 넣기 */}
             <TogetherReadCard
               title={togetherRead.title}
               participants={togetherRead.participants}
@@ -77,7 +74,7 @@ const MainPage: React.FC = () => {
               rank={togetherRead.rank}
               thumbnailUrl={togetherRead.thumbnailUrl}
               onClick={() => {
-                // TODO: 함께 읽기 상세/참여 페이지로 이동
+                // TODO: 함께 읽기 상세/참여 페이지로 이동, 여기도 캐러셀로 감싸기..
               }}
             />
           </section>
@@ -111,7 +108,7 @@ const MainPage: React.FC = () => {
           ))}
         </HorizontalBookScrollSection>
 
-        {/* ===== 지금 뜨거운 토론장 (캐러셀 + 도트) ===== */}
+        {/* ===== 지금 뜨거운 토론장 ===== */}
         <section className="mt-10">
           <h2 className="px-5 text-title5">지금 뜨거운 토론장</h2>
 
@@ -133,7 +130,7 @@ const MainPage: React.FC = () => {
           </CardCarousel>
         </section>
 
-        {/* ===== 나를 위한 인용구 (캐러셀 + 도트) ===== */}
+        {/* ===== 나를 위한 인용구 ===== */}
         <section className="mt-10">
           <h2 className="px-5 text-title5">나를 위한 인용구</h2>
 


### PR DESCRIPTION
## 📝 작업 내용

- 메인 페이지 UI를 구현하고 추가로 필요한 컴포넌트들을 구현했습니다.
- 가로로 책을 스크롤하는 컨테이너 컴포넌트를 추가했습니다. 오른쪽 그라데이션까지 구현해두었으니 마이페이지의 해당 섹션에도 이 컴포넌트를 적용하는 방향으로 수정해주시면 감사하겠습니다.
- 카드 컴포넌트를 가로로 슬라이드하는 Carousel 컴포넌트를 구현했습니다.
- 메인페이지의 헤더는 상단에 고정하고 검색창은 스크롤을 위로 올릴 때 내려오도록 구현했습니다. 다른 페이지에서도 헤더를 상단에 고정시키는 게 좋을 것 같습니다. 

## 📸 스크린샷 (선택)


https://github.com/user-attachments/assets/af5a9198-dc71-4be8-8ab8-2bfb2d5e689a



## 📢 발생한 이슈
아직 같이 읽기 카드 컴포넌트에는 캐러셀을 적용하지 않았습니다. 아래에 적용된 캐러셀과 다른 느낌을 주면 좋을 것 같아서 추후 구현 예정입니다.

## ✨ 리뷰어에게
피그마 요구사항대로 구현할 시에 전체적으로 텍스트가 너무 큰 것 같아서 조금 줄인 버전으로 구현했습니당... 

## 🔗 관련 이슈

- closed #50 