### PR TITLE
[Feat] 상세 페이지 인용구 API

### DIFF
--- a/src/api/detail/quote.api.ts
+++ b/src/api/detail/quote.api.ts
@@ -1,6 +1,17 @@
 import api from "../api";
 
-// 인용구 조회
+export type QuoteDetail = {
+  quote_id: number;
+  user_id: number;
+  nickname: string;
+  book_id: number;
+  content: string;
+  like_count: number;
+  created_at: string;
+  updated_at: string | null;
+};
+
+// 인용구 목록 조회
 export async function fetchQuotes(bookId: string | number) {
   return api.get(`/books/${bookId}/quotes/get`);
 }
@@ -8,4 +19,10 @@ export async function fetchQuotes(bookId: string | number) {
 // 인용구 생성
 export async function createQuote(bookId: string | number, content: string) {
   return api.post(`/books/${bookId}/quotes/post`, { content });
+}
+
+// 인용구 상세 조회
+export async function fetchQuoteDetail(quoteId: number): Promise<QuoteDetail> {
+  const data = await api.get<QuoteDetail>(`/quotes/${quoteId}/get`);
+  return data as unknown as QuoteDetail;
 }

--- a/src/api/detail/quote.api.ts
+++ b/src/api/detail/quote.api.ts
@@ -1,0 +1,11 @@
+import api from "../api";
+
+// 인용구 조회
+export async function fetchQuotes(bookId: string | number) {
+  return api.get(`/books/${bookId}/quotes/get`);
+}
+
+// 인용구 생성
+export async function createQuote(bookId: string | number, content: string) {
+  return api.post(`/books/${bookId}/quotes/post`, { content });
+}

--- a/src/pages/detail/BookDetailPage.tsx
+++ b/src/pages/detail/BookDetailPage.tsx
@@ -9,11 +9,12 @@ import {
   DiscussionCreateModal,
   QuoteCreateModal,
 } from '@/components';
-import { useParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router-dom';
 import { fetchBookDetail } from '@/api/detail/detail.api';
 import type { BookDetail } from '@/types/book';
 import { fetchQuotes } from '@/api/detail/quote.api';
 import { createQuote } from '@/api/detail/quote.api';
+import { formatKoreanDate } from '@/utils/date';
 
 const TAB_OPTIONS = ['토론', '인용구'] as const;
 type Tab = (typeof TAB_OPTIONS)[number];
@@ -28,9 +29,10 @@ const BookDetailPage: React.FC = () => {
   const [book, setBook] = useState<BookDetail | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  // 토론/인용구는 api 들어갈 자리
+  //토론 API 추후 연결
   const discussions: any[] = [];
   const [quotes, setQuotes]=useState<any[]>([]);
+  const navigate=useNavigate();
 
   const handleCreateDiscussion = () => {
     setOpenCreateModal(true);
@@ -38,16 +40,16 @@ const BookDetailPage: React.FC = () => {
 
   // ==== 인용구 조회 API ====
   useEffect(()=>{
-    if(!bookId) return;
+    if(!book?.bookId) return;
     (async ()=>{
       try{
-        const res=await fetchQuotes(bookId);
+        const res=await fetchQuotes(book.bookId);
         setQuotes(res.data??[]);
       }catch(err:any){
         console.error("인용구 불러오기 실패:", err);
       }
     })();
-  }, [bookId]);
+  }, [book?.bookId]);
 
   // ===== 도서 상세 API 호출 =====
   useEffect(() => {
@@ -105,7 +107,7 @@ const BookDetailPage: React.FC = () => {
 
   return (
     <div className="bg-beige1 min-h-screen">
-      <div className="fixed left-0 right-0 top-0 z-50">
+      <div className="fixed left-0 right-0 top-0 z-40">
         <Header variant="logoBookmark" />
       </div>
 
@@ -216,11 +218,11 @@ const BookDetailPage: React.FC = () => {
                   bookTitle={title} //책 제목도 안 내려와서 우선 상세 조회 API에서 받아오기
                   content={q.content}
                   tags={tags}
-                  nickname={'임시'} // 현재 api에서 닉네임을 안 내려줌,,,,
-                  dateLabel={q.created_at}
+                  nickname={q.nickname}
+                  dateLabel={formatKoreanDate(q.created_at)}
                   likeCount={q.like_count}
                   onClickCard={() => {
-                    // TODO: 인용구 상세
+                    navigate(`/quote/${q.quote_id}`)
                   }}
                 />
               ))
@@ -234,8 +236,8 @@ const BookDetailPage: React.FC = () => {
         onClose={() => setOpenQuoteModal(false)}
         onSubmit={async (quoteContent)=>{
           try{
-            await createQuote(bookId!, quoteContent);
-            const res=await fetchQuotes(bookId!);
+            await createQuote(book.bookId!, quoteContent);
+            const res=await fetchQuotes(book.bookId!);
             setQuotes(res.data??[]);
             setOpenQuoteModal(false);
           }catch(err:any){

--- a/src/pages/detail/BookDetailPage.tsx
+++ b/src/pages/detail/BookDetailPage.tsx
@@ -12,6 +12,8 @@ import {
 import { useParams } from 'react-router-dom';
 import { fetchBookDetail } from '@/api/detail/detail.api';
 import type { BookDetail } from '@/types/book';
+import { fetchQuotes } from '@/api/detail/quote.api';
+import { createQuote } from '@/api/detail/quote.api';
 
 const TAB_OPTIONS = ['토론', '인용구'] as const;
 type Tab = (typeof TAB_OPTIONS)[number];
@@ -26,10 +28,26 @@ const BookDetailPage: React.FC = () => {
   const [book, setBook] = useState<BookDetail | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  // 토론/인용구는 api 들어갈 자리
+  const discussions: any[] = [];
+  const [quotes, setQuotes]=useState<any[]>([]);
 
   const handleCreateDiscussion = () => {
     setOpenCreateModal(true);
   };
+
+  // ==== 인용구 조회 API ====
+  useEffect(()=>{
+    if(!bookId) return;
+    (async ()=>{
+      try{
+        const res=await fetchQuotes(bookId);
+        setQuotes(res.data??[]);
+      }catch(err:any){
+        console.error("인용구 불러오기 실패:", err);
+      }
+    })();
+  }, [bookId]);
 
   // ===== 도서 상세 API 호출 =====
   useEffect(() => {
@@ -84,10 +102,6 @@ const BookDetailPage: React.FC = () => {
 
   const coverImageUrl = thumbnailUrl;
   const tags = genres?.map((g) => g.genreName) ?? [];
-
-  // 토론/인용구는 아직 API 없다고 가정하고 빈 배열
-  const discussions: any[] = [];
-  const quotes: any[] = [];
 
   return (
     <div className="bg-beige1 min-h-screen">
@@ -197,14 +211,14 @@ const BookDetailPage: React.FC = () => {
             ) : (
               quotes.map((q) => (
                 <DiscussionCard
-                  key={q.id}
+                  key={q.quote_id}
                   type="quote"
-                  bookTitle={q.bookTitle}
+                  bookTitle={title} //책 제목도 안 내려와서 우선 상세 조회 API에서 받아오기
                   content={q.content}
                   tags={tags}
-                  nickname={q.nickname}
-                  dateLabel={q.dateLabel}
-                  likeCount={q.likeCount}
+                  nickname={'임시'} // 현재 api에서 닉네임을 안 내려줌,,,,
+                  dateLabel={q.created_at}
+                  likeCount={q.like_count}
                   onClickCard={() => {
                     // TODO: 인용구 상세
                   }}
@@ -218,9 +232,15 @@ const BookDetailPage: React.FC = () => {
       <QuoteCreateModal
         open={openQuoteModal}
         onClose={() => setOpenQuoteModal(false)}
-        onSubmit={(quote) => {
-          //TODO: 인용구 생성 API
-          console.log('인용구 생성 API 호출', quote);
+        onSubmit={async (quoteContent)=>{
+          try{
+            await createQuote(bookId!, quoteContent);
+            const res=await fetchQuotes(bookId!);
+            setQuotes(res.data??[]);
+            setOpenQuoteModal(false);
+          }catch(err:any){
+            console.error("인용구 생성 실패:", err);
+          }
         }}
       />
     </div>

--- a/src/pages/detail/QuoteDetailPage.tsx
+++ b/src/pages/detail/QuoteDetailPage.tsx
@@ -1,48 +1,114 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import { Image, Badge, Header } from "@/components";
-import { getQuoteDetailById, type QuoteDetailData } from "@/_mocks/quoteDetailMock";
 import { QuoteIcon } from "@/assets";
+import { fetchQuoteDetail } from "@/api/detail/quote.api";
+import { formatKoreanDate } from "@/utils/date";
 
 const QuoteDetailPage: React.FC = () => {
   const navigate = useNavigate();
   const { quoteId } = useParams<{ quoteId: string }>();
 
-  const id = Number(quoteId);
-  const data: QuoteDetailData | undefined = getQuoteDetailById(id);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
 
-  if (!data) {
+  // 인용구 상세 데이터
+  const [quote, setQuote] = useState<{
+    quote_id: number;
+    user_id: number;
+    nickname: string;
+    book_id: number;
+    content: string;
+    like_count: number;
+    created_at: string;
+    updated_at: string | null;
+  } | null>(null);
+
+  useEffect(() => {
+    if (!quoteId) {
+      setError("잘못된 접근입니다.");
+      setLoading(false);
+      return;
+    }
+
+    const id = Number(quoteId);
+    if (Number.isNaN(id)) {
+      setError("유효하지 않은 인용구 ID입니다.");
+      setLoading(false);
+      return;
+    }
+
+    (async () => {
+      try {
+        setLoading(true);
+        setError(null);
+
+        // 인터셉터 때문에 fetchQuoteDetail 결과는 바로 data 객체
+        const quoteData = await fetchQuoteDetail(id);
+        setQuote(quoteData);
+      } catch (err: any) {
+        console.error("인용구 상세 조회 실패:", err);
+        setError("인용구 정보를 불러오지 못했습니다.");
+      } finally {
+        setLoading(false);
+      }
+    })();
+  }, [quoteId]);
+
+  // ===== 로딩 / 에러 처리 =====
+  if (loading) {
     return (
-      <div className="min-h-screen bg-beige1 px-5 py-6">
-        <button
-          type="button"
-          onClick={() => navigate(-1)}
-          className="mb-4 text-caption2 text-gray3"
-        >
-          ← 뒤로가기
-        </button>
+      <div className="min-h-screen bg-beige1">
+        <Header
+          variant="backTitle"
+          title="인용구"
+          onBackClick={() => navigate(-1)}
+        />
         <p className="mt-10 text-center text-body3 text-gray4">
-          인용구 정보를 찾을 수 없습니다.
+          인용구 정보를 불러오는 중입니다…
         </p>
       </div>
     );
   }
 
-  const {
-    bookTitle,
-    author,
-    publisher,
-    coverUrl,
-    content,
-    writer,
-    date,
-    tags,
-  } = data;
+  if (error || !quote) {
+    return (
+      <div className="min-h-screen bg-beige1">
+        <Header
+          variant="backTitle"
+          title="인용구"
+          onBackClick={() => navigate(-1)}
+        />
+        <p className="mt-10 text-center text-body3 text-gray4">
+          {error ?? "인용구 정보를 찾을 수 없습니다."}
+        </p>
+      </div>
+    );
+  }
+
+  // ===== 화면에 쓸 데이터 매핑 =====
+  // 🔹 책 정보는 일단 임시 하드코딩
+  const bookTitle = "임시 책 제목";
+  const author = "임시 저자";
+  const publisher = "임시 출판사";
+  const coverUrl = "https://via.placeholder.com/80x112?text=Book";
+
+  const content = quote.content;
+  const writer = quote.nickname;
+  const date = formatKoreanDate(quote.created_at);
+
+  // 아직 태그 없음
+  const tags: { id: number; label: string }[] = [];
 
   return (
     <div className="min-h-screen bg-beige1">
       {/* 상단 헤더 */}
-      <Header variant="backTitle" title="인용구" onBackClick={()=>navigate(-1)}/>
+      <Header
+        variant="backTitle"
+        title="인용구"
+        onBackClick={() => navigate(-1)}
+      />
+
       <div className="px-5 py-3">
         {/* 책 정보 + 표지 */}
         <div className="flex items-center gap-4">
@@ -65,7 +131,7 @@ const QuoteDetailPage: React.FC = () => {
         </div>
 
         {/* 태그 뱃지 영역 */}
-        {tags && tags.length > 0 && (
+        {tags.length > 0 && (
           <div className="mt-4 flex flex-wrap gap-2">
             {tags.map((tag) => (
               <Badge key={tag.id} variant="tag" label={tag.label} />
@@ -79,18 +145,19 @@ const QuoteDetailPage: React.FC = () => {
         {/* 인용구 본문 */}
         <div className="mt-4 rounded-l bg-beige2 px-4 py-5">
           <div className="mb-2 flex items-center gap-2">
-            <span className="text-body4 text-gray3"><QuoteIcon className="w-4"/></span>
+            <span className="text-body4 text-gray3">
+              <QuoteIcon className="w-4" />
+            </span>
             <span className="text-caption4 text-gray3">인상 깊었던 문장</span>
           </div>
 
           <div className="flex gap-3 pt-1">
-            <div className="self-stretch w-1 rounded-full bg-gray1"/>
+            <div className="self-stretch w-1 rounded-full bg-gray1" />
             <p className="flex-1 whitespace-pre-line text-body2">
               {content}
             </p>
           </div>
         </div>
-
 
         {/* 작성자 / 날짜 */}
         <div className="mt-6 text-center">

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -1,0 +1,8 @@
+export const formatKoreanDate = (isoString: string) => {
+  return new Date(isoString).toLocaleString("ko-KR", {
+    timeZone: "Asia/Seoul",
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  });
+};


### PR DESCRIPTION
## 📝 작업 내용

- 책 상세 페이지에서 인용구를 조회하고 인용구를 생성하는 API를 연결했습니다.
- 현재 백엔드측 오류로 인해 API 연결 확인이 불가한 상태라서 우선 PR만 올려두고 추후 고쳐지는대로 수정하겠습니다.

## 📸 스크린샷 (선택)
<img width="2440" height="1222" alt="image" src="https://github.com/user-attachments/assets/fb47b5fe-eec4-4193-b873-c0254e652a4d" />
<img width="1081" height="675" alt="image" src="https://github.com/user-attachments/assets/d0053b7e-bc0f-4d2e-9fde-b8ee008f771a" />

<img width="2390" height="1106" alt="image" src="https://github.com/user-attachments/assets/c8e66124-6415-406b-b285-4102c169f2b2" />


## 📢 발생한 이슈
현재 인용구 상세 API가 피그마 요구사항과 맞지 않아 책 제목, 책 이미지, 저자 정보, 출판사 등은 임시 데이터로 채워두었습니다. 추후 API가 수정되면 연결부 수정하도록 하겠습니다.

## ✨ 리뷰어에게

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성

## 🔗 관련 이슈

- closed #61 