### PR TITLE
[feat] 토론 결과 페이지 구현

### DIFF
--- a/src/components/debate/ResultPage.tsx
+++ b/src/components/debate/ResultPage.tsx
@@ -1,0 +1,282 @@
+import React, { useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
+
+import { Header } from "@/components";
+
+import type { DebateMessage } from "@/_mocks/debateMock";
+import type {
+  Discussion,
+  DiscussionMessage,
+} from "@/api/detail/discussion.api";
+import { fetchDiscussionMessages } from "@/api/detail/discussion.api";
+import { getCurrentUserId } from "@/utils/auth";
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+const DEBATE_DURATION_DAYS = 7;
+
+interface VSDebateResultPageProps {
+  discussion: Discussion;
+}
+
+const VSDebateResultPage: React.FC<VSDebateResultPageProps> = ({
+  discussion,
+}) => {
+  const roomId = discussion.discussion_id;
+  const navigate = useNavigate();
+
+  const [messages, setMessages] = useState<DebateMessage[]>([]);
+  const [selectedSide, setSelectedSide] = useState<1 | 2 | null>(null);
+  const [hasVoted, setHasVoted] = useState(false);
+
+  // ===== 메시지 로드 =====
+  useEffect(() => {
+    if (!roomId) return;
+
+    (async () => {
+      try {
+        const apiMessages = await fetchDiscussionMessages(roomId);
+        const myId = getCurrentUserId();
+
+        const mapped = apiMessages.map(
+          (m: DiscussionMessage): DebateMessage => ({
+            id: m.comment_id,
+            debateRoomId: m.discussion_id,
+            author: myId && m.user_id === myId ? "me" : "other",
+            nickname: m.nickname,
+            content: m.content,
+            side:
+              m.choice === 1
+                ? 1
+                : m.choice === 2
+                ? 2
+                : undefined,
+          }),
+        );
+
+        setMessages(mapped);
+      } catch (e) {
+        console.error("VS 토론 메시지 불러오기 실패:", e);
+      }
+    })();
+  }, [roomId]);
+
+  // ===== 통계 계산 =====
+  const total = messages.length;
+  const side1Count = messages.filter((m) => m.side === 1).length;
+  const side2Count = messages.filter((m) => m.side === 2).length;
+
+  const side1Ratio = total ? Math.round((side1Count / total) * 100) : 0;
+  const side2Ratio = total ? 100 - side1Ratio : 0;
+
+  // 종료 날짜 계산 (created_at 기준 + 7일)
+  const createdAt = discussion.created_at
+    ? new Date(discussion.created_at)
+    : null;
+  const endedAt = createdAt
+    ? new Date(createdAt.getTime() + DEBATE_DURATION_DAYS * DAY_MS)
+    : null;
+
+  const formatDate = (d: Date | null) => {
+    if (!d) return "";
+    const yyyy = d.getFullYear();
+    const mm = `${d.getMonth() + 1}`.padStart(2, "0");
+    const dd = `${d.getDate()}`.padStart(2, "0");
+    return `${yyyy}.${mm}.${dd}`;
+  };
+
+  const option1 = discussion.option1 ?? "1번 의견";
+  const option2 = discussion.option2 ?? "2번 의견";
+
+  const handleVote = (side: 1 | 2) => {
+    if (hasVoted) return;
+    setSelectedSide(side);
+    setHasVoted(true);
+
+    // TODO: 여기서 실제 최종 투표 API 연동
+    // postFinalVote({ discussionId: roomId, choice: side });
+  };
+
+  return (
+    <div className="flex min-h-screen justify-center bg-beige1">
+      <div className="flex w-full flex-col">
+        <Header
+          variant="backTitleDropdown"
+          onBackClick={() => navigate(-1)}
+          title={discussion.title}
+          dropdownContent={
+            <div className="bg-beige2 pt-1">
+              <div className="flex flex-col gap-2">
+                <div className="flex items-center gap-2">
+                  <span className="inline-flex h-8 w-14 items-center justify-center rounded-m bg-yellow text-body2">
+                    1번
+                  </span>
+                  <span className="text-body2">{option1}</span>
+                </div>
+                <div className="flex items-center gap-2 pt-1">
+                  <span className="inline-flex h-8 w-14 items-center justify-center rounded-m bg-green1 text-body2 text-white">
+                    2번
+                  </span>
+                  <span className="text-body2">{option2}</span>
+                </div>
+              </div>
+            </div>
+          }
+        />
+
+        <section className="flex-1 px-5 pb-6 pt-6">
+          {/* 상단 카드 - 종료 안내 */}
+          <div className="mb-4 rounded-l bg-white p-4 shadow-sm">
+            <div className="mb-2 inline-flex items-center rounded-full border border-green1 bg-white px-3 py-1 text-caption5 text-green1">
+              VS 토론 종료
+            </div>
+            <h2 className="mb-1 text-title4">{discussion.title}</h2>
+            <p className="text-body2 text-gray3">
+              이 토론은{" "}
+              <span className="font-semibold">
+                {endedAt ? formatDate(endedAt) : "일주일 뒤"}
+              </span>
+              에 종료되었어요. 총{" "}
+              <span className="font-semibold">{total}</span>개의 의견이 오갔어요.
+            </p>
+          </div>
+
+          {/* 토론 요약 영역 (AI 요약 자리) */}
+          <div className="mb-4 rounded-l bg-white p-4 shadow-sm">
+            <h3 className="mb-2 text-title6">토론 요약</h3>
+            <p className="text-body2 text-gray3">
+              1번 측에서 {side1Count}개의 메시지, 2번 측에서 {side2Count}
+              개의 메시지가 작성되었어요.{" "}
+            </p>
+            <p className="text-body2 text-gray2">
+              AI토론 요약문 어쩌고 저쩌고 1번측은 이렇게 생각해요 2번측은
+              ~라는 의견을 내세웠지만 ~에 반박당했어요
+            </p>
+          </div>
+
+          {/* 의견 비율 바 */}
+          <div className="mb-4 rounded-l bg-white p-4 shadow-sm">
+            <h3 className="mb-3 text-title6">참여자 의견 비율</h3>
+
+            {/* 1번 */}
+            <div className="mb-2 flex items-center justify-between text-caption3 text-gray3">
+              <span>1번 의견</span>
+              <span>{side1Ratio}%</span>
+            </div>
+            <div className="mb-3 h-2 w-full overflow-hidden rounded-full bg-beige2">
+              <div
+                className="h-full rounded-full bg-yellow transition-all"
+                style={{ width: `${side1Ratio}%` }}
+              />
+            </div>
+
+            {/* 2번 */}
+            <div className="mb-2 flex items-center justify-between text-caption3 text-gray3">
+              <span>2번 의견</span>
+              <span>{side2Ratio}%</span>
+            </div>
+            <div className="h-2 w-full overflow-hidden rounded-full bg-beige2">
+              <div
+                className="h-full rounded-full bg-green1 transition-all"
+                style={{ width: `${side2Ratio}%` }}
+              />
+            </div>
+          </div>
+
+          {/* 🔥 최종 투표 카드 */}
+          <div className="rounded-l bg-white p-4 shadow-sm">
+            <h3 className="mb-2 text-title6">최종 투표</h3>
+            <p className="mb-4 text-body2 text-gray3">
+              이제 토론 내용을 바탕으로 어떤 의견에 더 공감하는지 선택해 주세요.
+              <br />
+              * 한 번만 선택할 수 있어요.
+            </p>
+
+            <div className="grid grid-cols-2 gap-3">
+              {/* 1번 카드 */}
+              <button
+                type="button"
+                onClick={() => handleVote(1)}
+                disabled={hasVoted && selectedSide !== 1}
+                className={`
+                  group flex h-24 flex-col justify-center rounded-l transition-all
+                  ${
+                    selectedSide === 1
+                      ? "bg-yellow text-black"
+                      : "bg-white text-gray3 shadow-sm active:scale-[0.98]"
+                  }
+                  ${
+                    hasVoted && selectedSide !== 1
+                      ? "opacity-50"
+                      : "hover:shadow-md"
+                  }
+                `}
+              >
+                <span
+                  className={`
+                    mb-2 inline-flex h-7 w-12 items-center justify-center rounded-m 
+                    ${
+                      selectedSide === 1
+                        ? "bg-black text-white"
+                        : "bg-yellow text-black"
+                    }
+                    text-caption3
+                  `}
+                >
+                  1번
+                </span>
+                <span className="text-caption2 font-medium">
+                  1번 의견에 투표
+                </span>
+              </button>
+
+              {/* 2번 카드 */}
+              <button
+                type="button"
+                onClick={() => handleVote(2)}
+                disabled={hasVoted && selectedSide !== 2}
+                className={`
+                  group flex h-24 flex-col justify-center rounded-l border transition-all
+                  ${
+                    selectedSide === 2
+                      ? "border-green1 bg-green1 text-white"
+                      : "border-gray1 bg-white text-gray3 shadow-sm active:scale-[0.98]"
+                  }
+                  ${
+                    hasVoted && selectedSide !== 2
+                      ? "opacity-50"
+                      : "hover:shadow-md"
+                  }
+                `}
+              >
+                <span
+                  className={`
+                    mb-2 inline-flex h-7 w-12 items-center justify-center rounded-m 
+                    ${
+                      selectedSide === 2
+                        ? "bg-white text-green1"
+                        : "bg-green1 text-white"
+                    }
+                    text-caption3
+                  `}
+                >
+                  2번
+                </span>
+                <span className="text-caption2 font-medium">
+                  2번 의견에 투표
+                </span>
+              </button>
+            </div>
+
+            {selectedSide && (
+              <p className="mt-3 text-center text-caption3 text-green1">
+                {selectedSide}번 의견에 투표했어요.
+              </p>
+            )}
+          </div>
+        </section>
+      </div>
+    </div>
+  );
+};
+
+export default VSDebateResultPage;

--- a/src/components/debate/ResultPage.tsx
+++ b/src/components/debate/ResultPage.tsx
@@ -182,7 +182,7 @@ const VSDebateResultPage: React.FC<VSDebateResultPageProps> = ({
             </div>
           </div>
 
-          {/* 🔥 최종 투표 카드 */}
+          {/* 최종 투표 카드 */}
           <div className="rounded-l bg-white p-4 shadow-sm">
             <h3 className="mb-2 text-title6">최종 투표</h3>
             <p className="mb-4 text-body2 text-gray3">

--- a/src/pages/debate/DebateRoomPage.tsx
+++ b/src/pages/debate/DebateRoomPage.tsx
@@ -6,6 +6,10 @@ import VSDebateRoomPage from "./VSDebateRoom";
 
 import { fetchDiscussionDetail } from "@/api/detail/discussion.api";
 import type { Discussion } from "@/api/detail/discussion.api";
+import VSDebateResultPage from "@/components/debate/ResultPage";
+
+const DAY_MS=24*60*60*1000;
+const DEBATE_DURATION_DAYS=7;
 
 const DebateRoomPage: React.FC = () => {
   const { debateRoomId } = useParams();
@@ -45,11 +49,24 @@ const DebateRoomPage: React.FC = () => {
     return <div>{error ?? "토론방을 찾을 수 없습니다."}</div>;
   }
 
+  //테스트용
+  //discussion.created_at=new Date(Date.now() -10*DAY_MS).toISOString();
+
+  const isVSClosed=
+    discussion.discussion_type==='VS'&&discussion.created_at
+    ? new Date(discussion.created_at).getTime()+
+      DEBATE_DURATION_DAYS*DAY_MS<=
+    Date.now()
+    :false;
+
   if (discussion.discussion_type === "FREE") {
     return <FreeDebateRoomPage discussion={discussion} />;
   }
 
   if (discussion.discussion_type === "VS") {
+    if(isVSClosed){
+      return <VSDebateResultPage discussion={discussion}/>;
+    }
     return <VSDebateRoomPage discussion={discussion} />;
   }
 


### PR DESCRIPTION
## 📝 작업 내용

- 토론 결과 페이지를 구현했습니다.
- 토론 종료 시 어떻게 응답이 내려오는지 몰라서 우선 VS 토론의 create_at 시점으로부터 7일이 지나면 해당 페이지가 렌더링되도록 구현해두었습니다. 
- 아직 7일을 경과한 토론이 존재하지 않아서 테스트 코드로 돌렸습니다! (현재는 주석처리 해두었습니다) 

## 📸 스크린샷 (선택)

<img width="944" height="1340" alt="image" src="https://github.com/user-attachments/assets/943c0e83-4370-4af0-bb6e-564bacef6fd0" />

## 📢 발생한 이슈

## ✨ 리뷰어에게

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성

## 🔗 관련 이슈

- closed #79