### PR TITLE
Feat/#108/메인페이지 수정

### DIFF
--- a/src/pages/main/Homepage.tsx
+++ b/src/pages/main/Homepage.tsx
@@ -460,7 +460,7 @@ const DefaultMainSections: React.FC<DefaultMainSectionsProps> = ({
       </HorizontalBookScrollSection>
 
       {/* 인기 도서 */}
-      <HorizontalBookScrollSection title="체크메이트의 인기 도서" className="pt-6">
+      <HorizontalBookScrollSection title="채크메이트의 인기 도서" className="pt-6">
         {bookLoading ? (
           <div className="text-caption4 text-gray3 px-5 py-2">불러오는 중...</div>
         ) : bookError ? (

--- a/src/pages/mypage/Setting.tsx
+++ b/src/pages/mypage/Setting.tsx
@@ -2,7 +2,6 @@ import React, { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 import { Header, BaseModal, Button } from '@/components';
-import { RightArrowIcon } from '@/assets';
 
 import {
   fetchSettingProfile,
@@ -45,11 +44,6 @@ const Setting: React.FC = () => {
 
     loadProfile();
   }, []);
-
-  // 1. 라이선스 페이지 이동
-  const handleLicenseClick = () => {
-    navigate('/mypage/setting/license'); // 추후 경로 수정
-  };
 
   // 2. 로그아웃 처리
   const handleLogoutConfirm = async () => {
@@ -118,15 +112,6 @@ const Setting: React.FC = () => {
 
         {/* 3. 앱 정보 영역 */}
         <section className="px-[37px] py-2">
-          {/* 라이선스 */}
-          <button
-            type="button"
-            onClick={handleLicenseClick}
-            className="flex w-full items-center justify-between py-4 cursor-pointer"
-          >
-            <span className="text-caption3 text-black">라이선스</span>
-            <RightArrowIcon className="w-[26px] h-[26px] text-black" />
-          </button>
 
           {/* 버전 정보 */}
           <div className="flex w-full items-center justify-between py-4">


### PR DESCRIPTION
## 📝 작업 내용

- 채크메이트의 인기도서라고 수정
- 설정 페이지의 라이선스 삭제

## 📸 스크린샷 (선택)

<img width="415" height="195" alt="image" src="https://github.com/user-attachments/assets/e1f10bec-e2ac-4459-8ad7-330ebf3d4532" />

<img width="443" height="474" alt="image" src="https://github.com/user-attachments/assets/d96c974e-c896-4df3-a395-e26cb028b004" />


## 📢 발생한 이슈

## ✨ 리뷰어에게

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성

## 🔗 관련 이슈

- closed #108 